### PR TITLE
[SPARK-LLAP-10] `DROP TABLE` should be blocked properly according to the access rule

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -91,6 +91,19 @@ private[spark] class LlapExternalCatalog(
     }
   }
 
+  override def dropTable(
+      db: String,
+      table: String,
+      ignoreIfNotExists: Boolean,
+      purge: Boolean): Unit = withClient {
+    requireDbExists(db)
+    val sessionState = SparkSession.getActiveSession.get.sessionState.asInstanceOf[LlapSessionState]
+    val stmt = sessionState.connection.createStatement()
+    val ifExistsString = if (ignoreIfNotExists) "IF EXISTS" else ""
+    val purgeString = if (purge) "PURGE" else ""
+    stmt.executeUpdate(s"DROP TABLE $ifExistsString $db.$table $purgeString")
+  }
+
   override def getTable(db: String, table: String): CatalogTable = withClient {
     val sessionState = SparkSession.getActiveSession.get.sessionState.asInstanceOf[LlapSessionState]
     val dmd = sessionState.connection.getMetaData()


### PR DESCRIPTION
This PR delegates `DROP TABLE` to Hive to use proper authorization.

This closes #10 .