### PR TITLE
[SPARK-LLAP-13] `DROP TABLE` fails on tables with `double` columns

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -174,7 +174,7 @@ class JDBCWrapper {
   def columnString(dataType: DataType, dataSize: Option[Long]): String = dataType match {
     case IntegerType => "INTEGER"
     case LongType => "BIGINT"
-    case DoubleType => "DOUBLE PRECISION"
+    case DoubleType => "DOUBLE"
     case FloatType => "REAL"
     case ShortType => "SMALLINT"
     case ByteType => "TINYINT"


### PR DESCRIPTION
Current, SPARK-LLAP fails to drop tables with `double` columns.

```sql
$ bin/beeline -u jdbc:hive2://localhost:10016 -n hive -p password -e 'drop table salary'
Connecting to jdbc:hive2://localhost:10016
...
Error: org.apache.spark.sql.catalyst.parser.ParseException:
extraneous input 'PRECISION' expecting {<EOF>, '('}(line 1, pos 7)

== SQL ==
DOUBLE PRECISION
-------^^^ (state=,code=0)
Closing: 0: jdbc:hive2://localhost:10016
```

The root cause is that `JDBCWrapper` returns `DOUBLE PRECISION` instead of `DOUBLE`.

This closes #13 .