### PR TITLE
[SPARK-LLAP-19] SHOW TABLE should support pattern filtering

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -180,7 +180,7 @@ private[spark] class LlapExternalCatalog(
   override def listTables(db: String, pattern: String): Seq[String] = withClient {
     val sessionState = SparkSession.getActiveSession.get.sessionState.asInstanceOf[LlapSessionState]
     val dmd = sessionState.connection.getMetaData()
-    val rs = dmd.getTables(null, db, "%", null)
+    val rs = dmd.getTables(null, db, pattern, null)
     var tableList: List[String] = Nil
     while (rs.next()) {
       tableList = rs.getString(3) :: tableList


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `SHOW TABLE 't*'` shows all tables. In other words, the pattern is ignored.

## How was this patch tested?

Manual.

This closes #19.