### PR TITLE
[SPARK-LLAP-21] ALTER TABLE should be handled correctly

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -79,11 +79,13 @@ private[sql] class LlapSessionCatalog(
    * in the database then a [[NoSuchTableException]] is thrown.
    */
   override def getTableMetadata(name: TableIdentifier): CatalogTable = {
-    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
-    val table = formatTableName(name.table)
-    val sessionState = sparkSession.sessionState.asInstanceOf[LlapSessionState]
-    val stmt = sessionState.connection.createStatement()
-    stmt.executeUpdate(s"DESC `$db`.`$table`")
+    if (Thread.currentThread().getStackTrace()(2).toString().contains("DescribeTableCommand")) {
+      val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
+      val table = formatTableName(name.table)
+      val sessionState = sparkSession.sessionState.asInstanceOf[LlapSessionState]
+      val stmt = sessionState.connection.createStatement()
+      stmt.executeUpdate(s"DESC `$db`.`$table`")
+    }
 
     super.getTableMetadata(name)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR handles the following ALTER TABLE statements correctly.

* ALTER TABLE ... RENAME TO
* ALTER TABLE ... SET TBLPROPERTIES
* ALTER TABLE ... UNSET TBLPROPERTIES
* ALTER TABLE ... ADD PARTITION
* ALTER TABLE ... DROP PARTITION
* ALTER TABLE ... PARTITION ... RENAME TO PARTITION
* ALTER TABLE ... PARTITION SET LOCATION
* ALTER TABLE ... RECOVER PARTITIONS

## How was this patch tested?

Manual.

This closes #21 and #22.