### PR TITLE
[SPARK-LLAP-36] Update answer files according to RANGER-1195

### DIFF
--- a/src/test/resources/answer/desc_t_alter.err_answer
+++ b/src/test/resources/answer/desc_t_alter.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_alter] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_alter/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_create.err_answer
+++ b/src/test/resources/answer/desc_t_create.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_create] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_create/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_drop.err_answer
+++ b/src/test/resources/answer/desc_t_drop.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_drop] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_drop/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_index.err_answer
+++ b/src/test/resources/answer/desc_t_index.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_index] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_index/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_lock.err_answer
+++ b/src/test/resources/answer/desc_t_lock.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_lock] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_lock/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_no.err_answer
+++ b/src/test/resources/answer/desc_t_no.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_no] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_no/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_partial.err_answer
+++ b/src/test/resources/answer/desc_t_partial.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_partial] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_partial/*] (state=42000,code=40000)

--- a/src/test/resources/answer/desc_t_update.err_answer
+++ b/src/test/resources/answer/desc_t_update.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_update] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_update/*] (state=42000,code=40000)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since RANGER-1195, Apache Ranger gives more accurate error message for `DESC` statements. We should update the answer files.

## How was this patch tested?

```bash
$ ./spark-ranger-test.py TableTestSuite.test_10_desc
.
----------------------------------------------------------------------
Ran 1 test in 52.666s

OK
```