### PR TITLE
[SPARK-LLAP-40] Database existence check should be handled correctly.

### DIFF
--- a/src/test/resources/answer/drop_db_2_db_no.err_answer
+++ b/src/test/resources/answer/drop_db_2_db_no.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [DROP] privilege on [db_no] (state=42000,code=40000)
+Error: org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database 'db_no' not found; (state=,code=0)

--- a/src/test/resources/answer/drop_db_cascade_3_db_no.err_answer
+++ b/src/test/resources/answer/drop_db_cascade_3_db_no.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [DROP] privilege on [db_no] (state=42000,code=40000)
+Error: org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database 'db_no' not found; (state=,code=0)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR implements the followings.
- Database existence check should not access HDFS directly.
- `SHOW DATABASES` should show the accessible databases.
- Re-add the `getTable` though JDBC feature to support fallback operation in case of direct access failure.

## How was this patch tested?

Pass the test.

This closes #40 .