### PR TITLE
[SPARK-LLAP-42] Add Python Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ Start Spark Thrift Server with `spark.sql.hive.llap=true`.
 
 You can turn off `spark-llap` by restarting Spark Thrift Server without this option or give `spark.sql.hive.llap=false`.
 
-It is recommended to run Spark Thrift Server as user `hive`.
+It is recommended to run Spark Thrift Server as user `hive` to use more SQL features.
 
 You can access `spark-llap` enabled Spark Thrift Server via `beeline` or Apache Zeppelin&trade;.
 
     beeline -u jdbc:hive2://localhost:10016 -n hive -p password -e 'show databases'
     beeline -u jdbc:hive2://localhost:10016 -n spark -p password -e 'show tables'
 
+There are two simple Python examples to submit jobs using Spark-LLAP.
+
+    examples/src/main/python/spark_llap_sql.py
+    examples/src/main/python/spark_llap_dsl.py
 
 ## Note for Kerberized Clusters
 
@@ -108,4 +112,5 @@ You can access `spark-llap` enabled Spark Thrift Server via `beeline` or Apache 
 
     beeline -u "jdbc:hive2://hostname:10500/;principal=hive/_HOST@EXAMPLE.COM;hive.server2.proxy.user=hive" -p password -e 'show tables'
     beeline -u "jdbc:hive2://hostname:10500/;principal=hive/_HOST@EXAMPLE.COM;hive.server2.proxy.user=spark" -p password -e 'show tables'
+
 

--- a/examples/src/main/python/spark_llap_dsl.py
+++ b/examples/src/main/python/spark_llap_dsl.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+
+from pyspark.sql import SparkSession
+
+
+if __name__ == "__main__":
+    """
+        Usage: bin/spark-submit --jars spark-llap_2.11-1.0.X-2.1.jar spark_llap_dsl.py
+    """
+    spark = SparkSession \
+        .builder \
+        .appName("Spark LLAP DSL Python") \
+        .master("yarn") \
+        .enableHiveSupport() \
+        .config("spark.sql.hive.llap", "true") \
+        .getOrCreate()
+
+    df = spark.sql("select * from db_spark.t_spark")
+
+    df.printSchema()
+
+    df.groupBy("a").count().show()
+
+    df.select("a").filter(df["a"] > 0).show()
+
+    spark.stop()

--- a/examples/src/main/python/spark_llap_sql.py
+++ b/examples/src/main/python/spark_llap_sql.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+
+from pyspark.sql import SparkSession
+
+
+if __name__ == "__main__":
+    """
+        Usage: bin/spark-submit --jars spark-llap_2.11-1.0.X-2.1.jar spark_llap_sql.py
+    """
+    spark = SparkSession \
+        .builder \
+        .appName("Spark LLAP SQL Python") \
+        .master("yarn") \
+        .enableHiveSupport() \
+        .config("spark.sql.hive.llap", "true") \
+        .getOrCreate()
+    spark.sql("show databases").show()
+    spark.sql("select * from db_spark.t_spark").show()
+    spark.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds python examples to show how to use `spark-submit`.

## How was this patch tested?

    bin/spark-submit --jars spark-llap_2.11-1.0.X-2.1.jar spark_llap_sql.py
    bin/spark-submit --jars spark-llap_2.11-1.0.X-2.1.jar spark_llap_dsl.py

This closes #42.