### PR TITLE
[SPARK-LLAP-48] Support `--packages` by making fat jar as default artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,11 @@
 
-name := "spark-llap_2.11"
+name := "spark-llap"
 version := "1.0.4-2.1"
 organization := "com.hortonworks"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
 sparkVersion := sys.props.getOrElse("spark.version", "2.1.0")
-
-assemblyJarName in assembly := s"${name.value}-${version.value}.jar"
 
 val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3")
 val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.5.3.0-37")
@@ -17,9 +15,6 @@ val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")
 val repoUrl = sys.props.getOrElse("repourl", "https://repo1.maven.org/maven2/")
 
 spName := "hortonworks/spark-llap"
-
-// disable using the Scala version in output paths and artifacts
-crossPaths := false
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -116,10 +111,11 @@ logLevel in assembly := {
   }
 }
 
-// Add assembly to publish task
+// Make assembly as default artifact
+publishArtifact in (Compile, packageBin) := false
 artifact in (Compile, assembly) := {
   val art = (artifact in (Compile, assembly)).value
-  art.copy(`classifier` = Some("assembly"))
+  art.copy(`classifier` = None)
 }
 addArtifact(artifact in (Compile, assembly), assembly)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to support `--packages` by making a fat jar as a default artifact.
Currently, it raises `RuntimeException` like the following.
```
$ spark-shell --packages com.hortonworks:spark-llap:1.0.0.2.5.3.0-37 --repositories http://repo.hortonworks.com/content/groups/public
scala> sql("show tables").show
17/01/31 00:31:38 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.RuntimeException: Stream '/jars/org.apache.curator_apache-curator-2.7.1.jar' was not found.
```

## How was this patch tested?

N/A