### PR TITLE
[SPARK-LLAP-50] Remove `incubating` from Apache Ranger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Spark&trade; connector for Apache Hive&trade; LLAP
 
 A library to load data into Apache Spark&trade; SQL DataFrames from
-Apache Hive&trade; using LLAP. With Apache Ranger&trade; (Incubating),
+Apache Hive&trade; using LLAP. With Apache Ranger&trade;,
 this library provides row/column level fine-grained access controls.
 
 - **Shared Policies**: The data in a cluster can be shared securely and


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache Ranger becomes TLP now.

https://blogs.apache.org/foundation/entry/the-apache-software-foundation-announces3

## How was this patch tested?

N/A

This closes #50.