### PR TITLE
[SPARK-LLAP-48] Support `--packages`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,13 +36,15 @@ libraryDependencies ++= Seq(
 
   ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "compile")
     .exclude("javax.servlet", "servlet-api")
-    .exclude("stax", "stax-api"),
+    .exclude("stax", "stax-api")
+    .exclude("org.apache.avro", "avro"),
 
   ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "compile")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")
-    .exclude("stax", "stax-api"),
+    .exclude("stax", "stax-api")
+    .exclude("org.apache.avro", "avro"),
 
   ("org.apache.tez" % "tez-runtime-internals" % tezVersion % "compile")
     .exclude("javax.servlet", "servlet-api")
@@ -51,6 +53,8 @@ libraryDependencies ++= Seq(
   ("org.apache.hive" % "hive-llap-ext-client" % hiveVersion)
     .exclude("ant", "ant")
     .exclude("org.apache.ant", "ant")
+    .exclude("org.apache.avro", "avro")
+    .exclude("org.apache.curator", "apache-curator")
     .exclude("org.apache.logging.log4j", "log4j-1.2-api")
     .exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
     .exclude("org.apache.logging.log4j", "log4j-web")
@@ -81,6 +85,7 @@ libraryDependencies ++= Seq(
     .exclude("org.apache.hadoop", "hadoop-yarn-server-common")
     .exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
     .exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
+    .exclude("org.apache.hbase", "hbase-client")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.6"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Up to now, `spark-llap` can be used with `--jars`, but fails on `--packages`.
This PR aims to support `--packages` by cleaning up the dependencies.

```
$ spark-shell --packages com.hortonworks:spark-llap_2-11:1.0.2-2.1 --repositories http://repo.hortonworks.com/content/groups/public
scala> sql("show tables").show
17/01/31 00:31:38 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.RuntimeException: Stream '/jars/org.apache.curator_apache-curator-2.7.1.jar' was not found.
```

## How was this patch tested?

After publishing to Maven, use `--packages` option.
