### PR TITLE
[SPARK-LLAP-59] Use `com.hortonworks.spark` instead of `com.hortonworks`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "spark-llap"
-version := "1.0.5-2.1"
-organization := "com.hortonworks"
+version := "1.0.6-2.1"
+organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
@@ -132,11 +132,9 @@ logLevel in assembly := {
   }
 }
 
-// Make assembly as default artifact
-publishArtifact in (Compile, packageBin) := false
 artifact in (Compile, assembly) := {
   val art = (artifact in (Compile, assembly)).value
-  art.copy(`classifier` = None)
+  art.copy(`classifier` = Some("assembly"))
 }
 addArtifact(artifact in (Compile, assembly), assembly)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes `groupId` from `com.hortonworks` into `com.hortonworks.spark`. Accordingly, this bump the version into `1.0.6`.

**BEFORE**
```xml
<groupId>com.hortonworks</groupId>
<artifactId>spark-llap_2.11</artifactId>
```

**AFTER**
```xml
<groupId>com.hortonworks.spark</groupId>
<artifactId>spark-llap_2.11</artifactId>
```

## How was this patch tested?

N/A