### PR TITLE
[SPARK-LLAP-62] Recover the change on default jar at SPARK-LLAP-59

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
 name := "spark-llap"
-version := "1.0.6-2.1"
+version := "1.0.7-2.1"
 organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
@@ -132,9 +132,11 @@ logLevel in assembly := {
   }
 }
 
+// Make assembly as default artifact
+publishArtifact in (Compile, packageBin) := false
 artifact in (Compile, assembly) := {
   val art = (artifact in (Compile, assembly)).value
-  art.copy(`classifier` = Some("assembly"))
+  art.copy(`classifier` = None)
 }
 addArtifact(artifact in (Compile, assembly), assembly)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SPARK-LLAP-59` accidentally *reverts* the code of `SPARK-LLAP-53`. This broke `--packages` support in `spark-shell`. This PR recovers that.

```
// Make assembly as default artifact
...
```


## How was this patch tested?

Manual.

```
SPARK_MAJOR_VERSION=2 spark-shell --packages com.hortonworks.spark:spark-llap_2.11:1.0.7-2.1 --repositories ... --conf spark.sql.hive.llap=true
```

This closes #62 .