### PR TITLE
[SPARK-LLAP-104] Override and shade netty-all dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ libraryDependencies ++= Seq(
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.6"
 dependencyOverrides += "commons-logging" % "commons-logging" % "1.2"
+dependencyOverrides += "io.netty" % "netty-all" % "4.0.42.Final"
 
 // Assembly rules for shaded JAR
 assemblyShadeRules in assembly := Seq(
@@ -111,7 +112,8 @@ assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("org.apache.hadoop.hive.shims.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.thrift.**" -> "shadehive.@0").inAll,
 
-  ShadeRule.rename("org.apache.derby.**" -> "shadederby.@0").inAll
+  ShadeRule.rename("org.apache.derby.**" -> "shadederby.@0").inAll,
+  ShadeRule.rename("io.netty.**" -> "shadenetty.@0").inAll
 )
 test in assembly := {}
 assemblyMergeStrategy in assembly := {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, spark-llap includes `netty-all` from Apache Hadoop which has different versions from Apache Spark. This PR overrides netty-all depenency to be consist with Apache Spark and also shades that.

## How was this patch tested?

Tested manually in the secure cluster and passed the following non-kerberized Ranger suite additionally.

```
[hive@hdp26-6 python]$ ./spark-ranger-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 323.545s

OK
[hive@hdp26-6 python]$ ./spark-ranger-test.py TableTestSuite
...................
----------------------------------------------------------------------
Ran 19 tests in 1843.179s

OK
```

This closes #104 