### PR TITLE
[Bug-64676] Should close/reuse connections in spark-llap

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -35,8 +35,7 @@ import org.apache.spark.sql.types.StructType
 
 case class LlapRelation(
     @transient sc: SQLContext,
-    @transient parameters: Map[String, String],
-    @transient conn: Connection)
+    @transient parameters: Map[String, String])
   extends BaseRelation
   with InsertableRelation
   with PrunedFilteredScan {
@@ -46,13 +45,23 @@ case class LlapRelation(
   }
 
   @transient val tableSchema: StructType = {
+    val connectionUrl = parameters("connectionUrl")
+    val user = parameters("user.name")
+    val conn = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
     val queryKey = getQueryType()
-    if (queryKey == "table") {
-      val (dbName, tableName) = getDbTableNames(parameters("table"))
-      DefaultJDBCWrapper.resolveTable(conn, dbName, tableName)
-    } else {
-      DefaultJDBCWrapper.resolveQuery(conn, parameters("query"))
+
+    try {
+      if (queryKey == "table") {
+        val (dbName, tableName) = getDbTableNames(parameters("table"))
+        DefaultJDBCWrapper.resolveTable(conn, dbName, tableName)
+      } else {
+        DefaultJDBCWrapper.resolveQuery(conn, parameters("query"))
+      }
+    } finally
+    {
+       conn.close()
     }
+
   }
 
   override def schema(): StructType = {
@@ -109,6 +118,10 @@ case class LlapRelation(
     val (dbName, tableName) = getDbTableNames(parameters("table"))
 
     val writer = new HiveWriter(sc)
+
+    val connectionUrl = parameters("connectionUrl")
+    val user = parameters("user.name")
+    val conn = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
     writer.saveDataFrameToHiveTable(data, dbName, tableName, conn, overwrite)
   }
 
@@ -189,6 +202,7 @@ class HiveWriter(sc: SQLContext) {
         var fs = FileSystem.get(new URI(tmpPath), sc.sparkContext.hadoopConfiguration)
         fs.delete(new Path(tmpPath), true)
       }
+      conn.close()
     }
   }
 

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -61,7 +61,6 @@ case class LlapRelation(
     {
        conn.close()
     }
-
   }
 
   override def schema(): StructType = {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -30,10 +30,10 @@ class DefaultSource extends RelationProvider {
     val sessionState = sqlContext.sparkSession.sessionState.asInstanceOf[LlapSessionState]
     val params = parameters +
       ("user.name" -> sessionState.getUserString()) +
-      ("user.password" -> "password")
+      ("user.password" -> "password") +
+      ("connectionUrl" -> sessionState.getConnectionUrl())
     LlapRelation(
       sqlContext,
-      params,
-      sessionState.connection)
+      params)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

I start and close the connection when it is used in the llap relation. 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
