### PR TITLE
[SPARK-LLAP-127] Table information will under access control

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
@@ -154,6 +154,19 @@ class LlapCatalog(override val client: ClientInterface, hive: LlapContext)
     val tableWithQualifiers = Subquery(tableIdentifier.table, logicalRelation)
     alias.map(a => Subquery(a, tableWithQualifiers)).getOrElse(tableWithQualifiers)
   }
+
+  override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
+    val db = databaseName.getOrElse(client.currentDatabase)
+    val pattern = "*"
+    val result = new scala.collection.mutable.ArrayBuffer[(String)]
+    val conn = hive.connection
+    val rs = conn.getMetaData.getTables(null, db, pattern, null)
+    while(rs.next()) {
+      result+=rs.getString(3)
+    }
+    rs.close()
+    result.map(name => (name, false))
+  }
 }
 
 object LlapContext {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
@@ -158,11 +158,11 @@ class LlapCatalog(override val client: ClientInterface, hive: LlapContext)
   override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
     val db = databaseName.getOrElse(client.currentDatabase)
     val pattern = "*"
-    val result = new scala.collection.mutable.ArrayBuffer[(String)]
+    val result = new scala.collection.mutable.ArrayBuffer[String]
     val conn = hive.connection
     val rs = conn.getMetaData.getTables(null, db, pattern, null)
     while(rs.next()) {
-      result+=rs.getString(3)
+      result += rs.getString(3)
     }
     rs.close()
     result.map(name => (name, false))


### PR DESCRIPTION
## What changes were proposed in this pull request?

I modify the LlapCatalog to enforce the access control under list tables. 

## How was this patch tested?

I test this manually on a security cluster based on spark 1.6. 
