### PR TITLE
[SPARK-LLAP-129][TEST][FOLLOW-UP] Update Ranger error message.

### DIFF
--- a/src/test/resources/answer/create_location_2_t_alter.err_answer
+++ b/src/test/resources/answer/create_location_2_t_alter.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_alter_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_create.err_answer
+++ b/src/test/resources/answer/create_location_2_t_create.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:java.security.AccessControlException: Permission denied: user=hive, access=WRITE, inode="/apps/hive":hdfs:hdfs:drwxr-xr-x

--- a/src/test/resources/answer/create_location_2_t_drop.err_answer
+++ b/src/test/resources/answer/create_location_2_t_drop.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_drop_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_full.err_answer
+++ b/src/test/resources/answer/create_location_2_t_full.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:java.security.AccessControlException: Permission denied: user=hive, access=WRITE, inode="/apps/hive":hdfs:hdfs:drwxr-xr-x

--- a/src/test/resources/answer/create_location_2_t_index.err_answer
+++ b/src/test/resources/answer/create_location_2_t_index.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_index_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_lock.err_answer
+++ b/src/test/resources/answer/create_location_2_t_lock.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_lock_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_no.err_answer
+++ b/src/test/resources/answer/create_location_2_t_no.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_no_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_partial.err_answer
+++ b/src/test/resources/answer/create_location_2_t_partial.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_partial_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_select.err_answer
+++ b/src/test/resources/answer/create_location_2_t_select.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_select_create_location_error] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_update.err_answer
+++ b/src/test/resources/answer/create_location_2_t_update.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [READ] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_update_create_location_error] (state=42000,code=40000)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR updates the test answer files for `test_22_create_location`.

**BEFORE**
```bash
$ python spark-ranger-secure-test.py
........F...............
----------------------------------------------------------------------
Ran 24 tests in 3165.302s
```

**AFTER**
```bash
$ python spark-ranger-secure-test.py TableTestSuite.test_22_create_location
.
----------------------------------------------------------------------
Ran 1 test in 178.611s

OK
```

## How was this patch tested?

Pass the test suite.