### PR TITLE
[SPARK-LLAP-137][TEST] Add Ranger HDFS policy and update error messages

### DIFF
--- a/src/test/resources/answer/create_location_2_t_alter.err_answer
+++ b/src/test/resources/answer/create_location_2_t_alter.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_alter_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_create.err_answer
+++ b/src/test/resources/answer/create_location_2_t_create.err_answer
@@ -1,1 +1,1 @@
-Error: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:java.security.AccessControlException: Permission denied: user=hive, access=WRITE, inode="/apps/hive":hdfs:hdfs:drwxr-xr-x
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_drop.err_answer
+++ b/src/test/resources/answer/create_location_2_t_drop.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_drop_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_full.err_answer
+++ b/src/test/resources/answer/create_location_2_t_full.err_answer
@@ -1,1 +1,1 @@
-Error: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:java.security.AccessControlException: Permission denied: user=hive, access=WRITE, inode="/apps/hive":hdfs:hdfs:drwxr-xr-x
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_index.err_answer
+++ b/src/test/resources/answer/create_location_2_t_index.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_index_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_lock.err_answer
+++ b/src/test/resources/answer/create_location_2_t_lock.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_lock_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_no.err_answer
+++ b/src/test/resources/answer/create_location_2_t_no.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_no_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_partial.err_answer
+++ b/src/test/resources/answer/create_location_2_t_partial.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_partial_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_select.err_answer
+++ b/src/test/resources/answer/create_location_2_t_select.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_select_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/answer/create_location_2_t_update.err_answer
+++ b/src/test/resources/answer/create_location_2_t_update.err_answer
@@ -1,1 +1,1 @@
-Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [CREATE] privilege on [spark_ranger_test/t_update_create_location_error] (state=42000,code=40000)
+Error: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [ALL] privilege on [hdfs://hdp26-1.openstacklocal:8020/apps/hive] (state=42000,code=40000)

--- a/src/test/resources/policies/5_hdfs.json
+++ b/src/test/resources/policies/5_hdfs.json
@@ -1,0 +1,71 @@
+{
+   "policies":[
+      {
+         "service":"cl1_hadoop",
+         "name":"spark_tmp",
+         "policyType":0,
+         "description":"",
+         "isAuditEnabled":true,
+         "resources":{
+            "path":{
+               "values":[
+                  "/tmp"
+               ],
+               "isExcludes":false,
+               "isRecursive":true
+            }
+         },
+         "policyItems":[
+            {
+               "accesses":[
+                  {
+                     "type":"read",
+                     "isAllowed":true
+                  },
+                  {
+                     "type":"write",
+                     "isAllowed":true
+                  },
+                  {
+                     "type":"execute",
+                     "isAllowed":true
+                  }
+               ],
+               "users":[
+                  "spark"
+               ],
+               "groups":[
+
+               ],
+               "conditions":[
+
+               ],
+               "delegateAdmin":false
+            }
+         ],
+         "denyPolicyItems":[
+
+         ],
+         "allowExceptions":[
+
+         ],
+         "denyExceptions":[
+
+         ],
+         "dataMaskPolicyItems":[
+
+         ],
+         "rowFilterPolicyItems":[
+
+         ],
+         "id":30,
+         "isEnabled":true,
+         "version":1
+      }
+   ],
+   "startIndex":0,
+   "pageSize":0,
+   "totalCount":0,
+   "resultSize":0,
+   "queryTimeMS":1490156630296
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDP 2.6.1, there are two differences.
- `hdfs://tmp` is not allowed by default. We need HDFS plugin policy.
- INSERT INTO / CREATE TABLE / CREATE TABLE with LOCATION error messages are changed.

## How was this patch tested?

```
[hive@hdp26-6 python]$ python spark-ranger-secure-test.py TableTestSuite.test_21_create_as
.
----------------------------------------------------------------------
Ran 1 test in 204.527s

OK
[hive@hdp26-6 python]$ python spark-ranger-secure-test.py TableTestSuite.test_22_create_location
.
----------------------------------------------------------------------
Ran 1 test in 187.236s

OK
[hive@hdp26-6 python]$ python spark-ranger-secure-test.py TableTestSuite.test_70_insert
.
----------------------------------------------------------------------
Ran 1 test in 157.783s

OK
```

This closes #137 .