### PR TITLE
[SPARK-LLAP-125][BRANCH-1.6] Reduce the number of included artifacts …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ val scalatestVersion = "2.2.4"
 
 sparkVersion := sys.props.getOrElse("spark.version", "1.6.3")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3")
-val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.5.3.0-37")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3.2.6.1.0-129")
+val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.6.1.0-129")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
 val tezVersion = sys.props.getOrElse("tez.version", "0.8.4")
 val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")
@@ -31,15 +31,18 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force(),
 
-  "org.scala-lang" % "scala-library" % scalaVersion.value % "compile",
+  "org.scala-lang" % "scala-library" % scalaVersion.value % "provided",
   "org.scalatest" %% "scalatest" % scalatestVersion % "test",
 
-  ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "compile")
+  ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "provided")
     .exclude("javax.servlet", "servlet-api")
     .exclude("stax", "stax-api")
-    .exclude("org.apache.avro", "avro"),
+    .exclude("org.apache.avro", "avro")
+    .exclude("commons-beanutils", "commons-beanutils-core")
+    .exclude("commons-collections", "commons-collections")
+    .exclude("commons-logging", "commons-logging"),
 
-  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "compile")
+  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")
@@ -48,7 +51,16 @@ libraryDependencies ++= Seq(
 
   ("org.apache.tez" % "tez-runtime-internals" % tezVersion % "compile")
     .exclude("javax.servlet", "servlet-api")
-    .exclude("stax", "stax-api"),
+    .exclude("stax", "stax-api")
+    .exclude("commons-beanutils", "commons-beanutils-core")
+    .exclude("commons-collections", "commons-collections")
+    .exclude("commons-logging", "commons-logging")
+    .exclude("org.apache.hadoop", "hadoop-yarn-client")
+    .exclude("org.apache.hadoop", "hadoop-yarn-common")
+    .exclude("org.apache.hadoop", "hadoop-yarn-api")
+    .exclude("org.apache.hadoop", "hadoop-annotations")
+    .exclude("org.apache.hadoop", "hadoop-auth")
+    .exclude("org.apache.hadoop", "hadoop-hdfs"),
 
   ("org.apache.hive" % "hive-llap-ext-client" % hiveVersion)
     .exclude("ant", "ant")
@@ -86,10 +98,23 @@ libraryDependencies ++= Seq(
     .exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
     .exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
     .exclude("org.apache.hbase", "hbase-client")
+    .exclude("org.apache.hadoop", "hadoop-common")
+    .exclude("org.apache.hadoop", "hadoop-hdfs")
+    .exclude("org.apache.hbase", "*")
+    .exclude("commons-beanutils", "commons-beanutils-core")
+    .exclude("commons-collections", "commons-collections")
+    .exclude("commons-logging", "commons-logging")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.6"
 dependencyOverrides += "commons-logging" % "commons-logging" % "1.2"
+dependencyOverrides += "org.apache.httpcomponents" % "httpclient" % "4.5.2"
+dependencyOverrides += "org.apache.httpcomponents" % "httpcore" % "4.4.4"
+dependencyOverrides += "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13"
+dependencyOverrides += "org.codehaus.jackson" % "jackson-jaxrs" % "1.9.13"
+dependencyOverrides += "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13"
+dependencyOverrides += "org.codehaus.jackson" % "jackson-xc" % "1.9.13"
+dependencyOverrides += "org.apache.commons" % "commons-lang3" % "3.4"
 
 // Assembly rules for shaded JAR
 assemblyShadeRules in assembly := Seq(
@@ -108,6 +133,7 @@ assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("org.apache.hadoop.hive.serde2.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.shims.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.thrift.**" -> "shadehive.@0").inAll,
+  ShadeRule.rename("org.apache.curator.**" -> "shadecurator.@0").inAll,
 
   ShadeRule.rename("org.apache.derby.**" -> "shadederby.@0").inAll,
   ShadeRule.rename("io.netty.**" -> "shadenetty.@0").inAll


### PR DESCRIPTION
…in the uber jar

## What changes were proposed in this pull request?

1. change some artifact from compile to provided
2. exclude the hadoop common, hdfs etc from hive
3. remove the force for the spark
4. exclude: commons-beanutils etc

## How was this patch tested?

This patch is backport from branch-2.1 and it is already tested. 
