### PR TITLE
Push down count(*) query to Hive when requiredColumns is an empty list.

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -85,26 +85,31 @@ case class LlapRelation(
 
   // PrunedFilteredScan implementation
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+    val countStar = requiredColumns.isEmpty
     val queryString = getQueryString(requiredColumns, filters)
 
-    @transient val inputFormatClass = classOf[LlapRowInputFormat]
-    @transient val jobConf = new JobConf(sc.sparkContext.hadoopConfiguration)
-    // Set JDBC url/etc
-    jobConf.set("llap.if.hs2.connection", parameters("url"))
-    jobConf.set("llap.if.query", queryString)
-    var userName = getUser()
-    jobConf.set("llap.if.user", userName)
-    jobConf.set("llap.if.pwd", "password")
+    if (countStar) {
+      handleCountStar(queryString)
+    } else {
+      @transient val inputFormatClass = classOf[LlapRowInputFormat]
+      @transient val jobConf = new JobConf(sc.sparkContext.hadoopConfiguration)
+      // Set JDBC url/etc
+      jobConf.set("llap.if.hs2.connection", parameters("url"))
+      jobConf.set("llap.if.query", queryString)
+      var userName = getUser()
+      jobConf.set("llap.if.user", userName)
+      jobConf.set("llap.if.pwd", "password")
 
-    // This should be set to the number of executors
-    val numPartitions = sc.sparkContext.defaultMinPartitions
-    val rdd = sc.sparkContext.hadoopRDD(jobConf, inputFormatClass,
-        classOf[NullWritable], classOf[org.apache.hadoop.hive.llap.Row], numPartitions)
-        .asInstanceOf[HadoopRDD[NullWritable, org.apache.hadoop.hive.llap.Row]]
+      // This should be set to the number of executors
+      val numPartitions = sc.sparkContext.defaultMinPartitions
+      val rdd = sc.sparkContext.hadoopRDD(jobConf, inputFormatClass,
+          classOf[NullWritable], classOf[org.apache.hadoop.hive.llap.Row], numPartitions)
+          .asInstanceOf[HadoopRDD[NullWritable, org.apache.hadoop.hive.llap.Row]]
 
-    // Convert from RDD into Spark Rows
-    val preservesPartitioning = false; // ???
-    rdd.mapPartitionsWithInputSplit(LlapRelation.llapRowRddToRows, preservesPartitioning)
+      // Convert from RDD into Spark Rows
+      val preservesPartitioning = false; // ???
+      rdd.mapPartitionsWithInputSplit(LlapRelation.llapRowRddToRows, preservesPartitioning)
+    }
   }
 
   // InsertableRelation implementation
@@ -128,7 +133,7 @@ case class LlapRelation(
   }
 
   private def getQueryString(requiredColumns: Array[String], filters: Array[Filter]): String = {
-    var selectCols = "*"
+    var selectCols = "count(*)"
     if (requiredColumns.length > 0) {
       selectCols = requiredColumns.mkString(",")
     }
@@ -162,6 +167,25 @@ case class LlapRelation(
     sc match {
       case _ => DefaultJDBCWrapper.getConnector(None, parameters("url"), getUser())
     }
+  }
+
+  private def handleCountStar(queryString: String): RDD[Row] = {
+    tryWithResource(getConnection()) { conn =>
+      tryWithResource(conn.createStatement()) { stmt =>
+        val rs = stmt.executeQuery(queryString)
+        if (rs.next()) {
+          val countStarValue = rs.getLong(1)
+          sqlContext.sparkContext.parallelize(1L to countStarValue).map(_ => Row.empty)
+        } else {
+          throw new IllegalStateException("Failed to read count star value")
+        }
+      }
+    }
+  }
+
+  private def tryWithResource[R <: AutoCloseable, T](createResource: => R)(f: R => T): T = {
+    val resource = createResource
+    try f.apply(resource) finally resource.close()
   }
 }
 


### PR DESCRIPTION
This improves performance of count(*) queries since we were previously selecting all columns of the table.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
