### PR TITLE
[SPARK-LLAP-133][BRANCH-1.6] Access control for DESC TABLE

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapContext.scala
@@ -23,7 +23,9 @@ import java.util.{Map => JMap}
 import java.util.regex.Pattern
 
 import scala.reflect.runtime.{universe => ru}
+
 import com.hortonworks.spark.sql.hive.llap.DefaultJDBCWrapper
+
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Row, SQLConf, SQLContext}
 import org.apache.spark.sql.SQLConf.SQLConfEntry.stringConf
@@ -39,7 +41,7 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.hive.HiveMetastoreCatalog
 import org.apache.spark.sql.hive.MetastoreRelation
 import org.apache.spark.sql.hive.client.{ClientInterface, ClientWrapper, HiveDatabase, HiveTable}
-import org.apache.spark.sql.hive.execution.{DescribeHiveTableCommand, HiveNativeCommand}
+import org.apache.spark.sql.hive.execution._
 
 
 class LlapContext(sc: SparkContext,
@@ -139,15 +141,12 @@ class LlapContext(sc: SparkContext,
         var database = ""
         var tablename = ""
         val args = desc.argString
-        args.split(",").foreach{
-          s =>
-            if (s.contains("table"))
-              {
+        args.split(",").foreach{ s =>
+            if (s.contains("table")) {
                 val tables = s.split("->")
                 val nameParts = tables{1}.split("\\.")
                 if (nameParts.length != 2) {
-                  throw new IllegalArgumentException
-                  ("Expected " + s + " to be in the form db.table")
+                  throw new IllegalArgumentException("Expected " + s + " to be form of db.table")
                 }
                 database = nameParts(0).trim
                 tablename = nameParts(1).trim


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the access control for describe database.table

**BEFORE**
```
0: jdbc:hive2://ctr-e133-1493418528701-160107> desc spark_ranger_test.t_no;
+-----------+------------+----------+--+
| col_name  | data_type  | comment  |
+-----------+------------+----------+--+
+-----------+------------+----------+--+
No rows selected (0.782 seconds)

0: jdbc:hive2://ctr-e133-1493418528701-160107> desc spark_ranger_test.t_full;
+-----------+------------+----------+--+
| col_name  | data_type  | comment  |
+-----------+------------+----------+--+
| a         | int        |          |
| b         | int        |          |
+-----------+------------+----------+--+
```

**AFTER**

```
0: jdbc:hive2://ctr-e133-1493418528701-160107> desc spark_ranger_test.t_no;
Error: shadehive.org.apache.hive.service.cli.HiveSQLException: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_no/*] (state=,code=0)

0: jdbc:hive2://ctr-e133-1493418528701-160107> desc spark_ranger_test.t_full;
+-----------+------------+----------+--+
| col_name  | data_type  | comment  |
+-----------+------------+----------+--+
| a         | int        |          |
| b         | int        |          |
+-----------+------------+----------+--+
2 rows selected (3.18 seconds)

0: jdbc:hive2://ctr-e133-1493418528701-160107> desc spark_ranger_test.t_partial;
Error: shadehive.org.apache.hive.service.cli.HiveSQLException: Error while compiling statement: FAILED: HiveAccessControlException Permission denied: user [spark] does not have [SELECT] privilege on [spark_ranger_test/t_partial/*] (state=,code=0)
```

## How was this patch tested?

Pass the test suite.

```
[root@ctr-e133-1493418528701-160107-01-000009 python]# ./spark-ranger-secure-test.py TableTestSuite
......
----------------------------------------------------------------------
Ran 6 tests in 708.943s

OK
```