### PR TITLE
[SPARK-LLAP-157] Use CREATE EXTERNAL TABLE to check permission

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -181,8 +181,9 @@ private[spark] class LlapExternalCatalog(
       } else {
         ""
       }
-      executeUpdate(s"CREATE TABLE ${tableDefinition.identifier.quotedString} (dummy INT) " +
-        location)
+      // Check with `EXTERNAL` keyword in order not to drop or change the existing location.
+      executeUpdate(
+        s"CREATE EXTERNAL TABLE ${tableDefinition.identifier.quotedString} (dummy INT) " + location)
       super.dropTable(db, tableDefinition.identifier.table, ignoreIfNotExists = true, purge = true)
       super.createTable(tableDefinition, ignoreIfExists)
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR uses `CREATE EXTERNAL TABLE` instead of `CREATE TABLE` to avoid accidental dropping or chaning the existing location. This might happen in some cases.

This closes #157 .

## How was this patch tested?

Pass the test suite. I tested this in HDP 2.6.1.0.
```
[hive@hdp26-6 python]$ ./spark-ranger-secure-test.py
.........................
----------------------------------------------------------------------
Ran 25 tests in 3670.599s

OK
```