### PR TITLE
[SPARK-LLAP-156] Support LlapRelation table size.

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -178,6 +178,14 @@ case class LlapRelation(
     val resource = createResource
     try f.apply(resource) finally resource.close()
   }
+
+  override def sizeInBytes(): Long = {
+    if (parameters.isDefinedAt("sizeinbytes")) {
+      parameters("sizeinbytes").toLong
+    } else {
+      super.sizeInBytes
+    }
+  }
 }
 
 object LlapRelation {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapMetastoreCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapMetastoreCatalog.scala
@@ -41,6 +41,9 @@ class LlapMetastoreCatalog(sparkSession: SparkSession)
     val catalog = sparkSession.sharedState.externalCatalog.asInstanceOf[LlapExternalCatalog]
     val table = catalog.getTable(qualifiedTableName.database, qualifiedTableName.name)
 
+    val metastoreRelation = MetastoreRelation(qualifiedTableName.database, qualifiedTableName.name)(table, sparkSession)
+    val size = metastoreRelation.statistics.sizeInBytes
+
     // Now convert to LlapRelation
     val sessionState = sparkSession.sessionState.asInstanceOf[LlapSessionState]
     val logicalRelation = LogicalRelation(
@@ -49,6 +52,7 @@ class LlapMetastoreCatalog(sparkSession: SparkSession)
         className = "org.apache.spark.sql.hive.llap",
         options = Map(
           "table" -> (qualifiedTableName.database + "." + qualifiedTableName.name),
+          "sizeinbytes" -> size.toString(),
           "url" -> sessionState.getConnectionUrl())
       ).resolveRelation())
 

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapMetastoreCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapMetastoreCatalog.scala
@@ -41,7 +41,8 @@ class LlapMetastoreCatalog(sparkSession: SparkSession)
     val catalog = sparkSession.sharedState.externalCatalog.asInstanceOf[LlapExternalCatalog]
     val table = catalog.getTable(qualifiedTableName.database, qualifiedTableName.name)
 
-    val metastoreRelation = MetastoreRelation(qualifiedTableName.database, qualifiedTableName.name)(table, sparkSession)
+    val metastoreRelation =
+      MetastoreRelation(qualifiedTableName.database, qualifiedTableName.name)(table, sparkSession)
     val size = metastoreRelation.statistics.sizeInBytes
 
     // Now convert to LlapRelation


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR supports `sizeInBytes()` in LlapRelation.

## How was this patch tested?

Pass the test suite. It's tested on HDP 2.6.1.0.
```
$ python spark-ranger-secure-test.py
.........................
----------------------------------------------------------------------
Ran 25 tests in 3706.998s

OK
```