### PR TITLE
[SPARK-LLAP-160] Consider connection pooling to reuse connections to HS2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ dependencyOverrides += "org.codehaus.jackson" % "jackson-jaxrs" % "1.9.13"
 dependencyOverrides += "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13"
 dependencyOverrides += "org.codehaus.jackson" % "jackson-xc" % "1.9.13"
 dependencyOverrides += "org.apache.commons" % "commons-lang3" % "3.4"
+libraryDependencies += "org.apache.commons" % "commons-dbcp2" % "2.1"
 
 
 // Assembly rules for shaded JAR

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging"),
 
-  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "compile")
+  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging"),
 
-  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
+  ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "compile")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -183,7 +183,6 @@ class JDBCWrapper {
         datasource.setUrl(url)
         datasource.setUsername(userName)
         datasource.setPassword("password")
-        datasource.setMaxConnLifetimeMillis(1000)
         connectionPools.put(userName, datasource)
         datasource.getConnection
     }

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -23,7 +23,7 @@ import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet,
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.dbcp.BasicDataSource
+import org.apache.commons.dbcp2.BasicDataSource
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 import org.apache.hadoop.hive.serde2.typeinfo._
@@ -53,7 +53,7 @@ class JDBCWrapper {
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val connectionPool = new BasicDataSource;
+  private val connectionPool = new BasicDataSource
 
   private val initConnectionPool = {
     connectionPool.setInitialSize(100)

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -22,7 +22,6 @@ import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet,
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable
 
 import org.apache.commons.dbcp2.BasicDataSource
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -53,7 +53,7 @@ class JDBCWrapper {
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val connectionPools = new mutable.HashMap[String, BasicDataSource]
+  private val connectionPools = new scala.collection.mutable.HashMap[String, BasicDataSource]
 
   /**
    * Given a JDBC subprotocol, returns the appropriate driver class so that it can be registered

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -183,14 +183,14 @@ class JDBCWrapper {
         datasource.setUrl(url)
         datasource.setUsername(userName)
         // for hdp older version support without dbcp2 configurations
-        if(dbcp2Configs == null) {
-            datasource.setInitialSize(2)
-            datasource.setMaxConnLifetimeMillis(2000)
-            datasource.setMaxTotal(100)
-            datasource.setMaxIdle(50)
+        if (dbcp2Configs == null) {
+            datasource.setInitialSize(1)
+            datasource.setMaxConnLifetimeMillis(5000)
+            datasource.setMaxTotal(20)
+            datasource.setMaxIdle(10)
             datasource.setMaxWaitMillis(4000)
           } else {
-              dbcp2Configs.split(" ").map(s => s.trim.split(":")).foreach {
+            dbcp2Configs.split(" ").map(s => s.trim.split(":")).foreach {
               conf => datasource.addConnectionProperty(conf(0), conf(1))
               log.debug(conf(0) + ":" + conf(1))
             }

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -47,7 +47,8 @@ case class LlapRelation(
   @transient val tableSchema: StructType = {
     val connectionUrl = parameters("connectionUrl")
     val user = parameters("user.name")
-    val conn = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
+    val dbcp2Configs = parameters("dbcp2.conf")
+    val conn = DefaultJDBCWrapper.getConnector(None, connectionUrl, user, dbcp2Configs)
     val queryKey = getQueryType()
 
     try {
@@ -129,7 +130,8 @@ case class LlapRelation(
   private def getConnection(): Connection = {
     val connectionUrl = parameters("connectionUrl")
     val user = parameters("user.name")
-    DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
+    val dbcp2Configs = parameters("dbcp2.conf")
+    DefaultJDBCWrapper.getConnector(None, connectionUrl, user, dbcp2Configs)
   }
 
   private def getDbTableNames(nameStr: String): Tuple2[String, String] = {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -28,9 +28,11 @@ class DefaultSource extends RelationProvider {
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String])
       : BaseRelation = {
     val sessionState = sqlContext.sparkSession.sessionState.asInstanceOf[LlapSessionState]
+    val dbcp2Config = sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
     val params = parameters +
       ("user.name" -> sessionState.getUserString()) +
       ("user.password" -> "password") +
+      ("dbcp2.conf" -> dbcp2Config) +
       ("connectionUrl" -> sessionState.getConnectionUrl())
     LlapRelation(
       sqlContext,

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionState.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionState.scala
@@ -54,8 +54,8 @@ class LlapSessionState(sparkSession: SparkSession)
    * Return connection.
    */
   def connection: Connection = {
-    val dbcp2Config = sparkSession.sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
-    DefaultJDBCWrapper.getConnector(None, getConnectionUrl(), getUserString(), dbcp2Config)
+    val dbcp2Configs = sparkSession.sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
+    DefaultJDBCWrapper.getConnector(None, getConnectionUrl(), getUserString(), dbcp2Configs)
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionState.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionState.scala
@@ -54,7 +54,8 @@ class LlapSessionState(sparkSession: SparkSession)
    * Return connection.
    */
   def connection: Connection = {
-    DefaultJDBCWrapper.getConnector(None, getConnectionUrl(), getUserString())
+    val dbcp2Config = sparkSession.sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
+    DefaultJDBCWrapper.getConnector(None, getConnectionUrl(), getUserString(), dbcp2Config)
   }
 
   /**

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
@@ -25,8 +25,8 @@ object TestUtils {
       spark: SparkSession,
       connectionUrl: String,
       userName: String,
-      dbcp2Conf : String): Unit = {
-    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName, dbcp2Conf)
+      dbcp2Confs : String): Unit = {
+    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName, dbcp2Confs)
     val settings = Seq(
       "hive.llap.daemon.service.hosts",
       "hive.zookeeper.quorum",

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
@@ -24,8 +24,9 @@ object TestUtils {
   def updateConfWithMiniClusterSettings(
       spark: SparkSession,
       connectionUrl: String,
-      userName: String): Unit = {
-    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName)
+      userName: String,
+      dbcp2Conf : String): Unit = {
+    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName, dbcp2Conf)
     val settings = Seq(
       "hive.llap.daemon.service.hosts",
       "hive.zookeeper.quorum",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use DBCP2 for creating the connection pool for each user. 

## How was this patch tested?

**BEFORE**
```
root@ctr-e134-1499953498516-70977-01-000007 python# ./spark-ranger-secure-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 625.247s
OK
```

**AFTER** 
```
root@ctr-e134-1499953498516-70977-01-000007 python# ./spark-ranger-secure-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 566.203s
OK

[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 2966.754s