### PR TITLE
[SPARK-LLAP-157] Use CREATE EXTERNAL TABLE to check permission

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -194,8 +194,9 @@ private[spark] class LlapExternalCatalog(
       } else {
         ""
       }
-      executeUpdate(s"CREATE TABLE ${tableDefinition.identifier.quotedString} (dummy INT) " +
-        location)
+      // Check with `EXTERNAL` keyword in order not to drop or change the existing location.
+      executeUpdate(
+        s"CREATE EXTERNAL TABLE ${tableDefinition.identifier.quotedString} (dummy INT) " + location)
       super.doDropTable(db, tableDefinition.identifier.table,
         ignoreIfNotExists = true, purge = true)
       super.doCreateTable(tableDefinition, ignoreIfExists)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR uses `CREATE EXTERNAL TABLE` instead of `CREATE TABLE` to avoid accidental dropping or chaning the existing location. This might happen in some cases.

This closes #162 .

## How was this patch tested?

Pass the test suite.

```
[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 653.713s

[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 3887.564s
```