### PR TITLE
[Hotfix] SparkSessionState change function name getUserNameString to …

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -32,7 +32,7 @@ class DefaultSource extends RelationProvider {
       getMethod("getConnectionUrl", classOf[SparkSession])
     val connectionUrl = getConnectionUrlMethod.
       invoke(sessionState, sqlContext.sparkSession).toString()
-    val getUserMethod = sessionState.getClass.getMethod("getUserString")
+    val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
     val params = parameters +
       ("user.name" -> user) +

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -78,7 +78,7 @@ private[spark] class LlapExternalCatalog(
     val getConnectionUrlMethod = sessionState.getClass.
       getMethod("getConnectionUrl", classOf[SparkSession])
     val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
-    val getUserMethod = sessionState.getClass.getMethod("getUserString")
+    val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
     val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
     connection

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -100,7 +100,7 @@ private[sql] class LlapSessionCatalog(
       val getConnectionUrlMethod = sessionState.getClass.
         getMethod("getConnectionUrl", classOf[SparkSession])
       val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
-      val getUserMethod = sessionState.getClass.getMethod("getUserString")
+      val getUserMethod = sessionState.getClass.getMethod("getUser")
       val user = getUserMethod.invoke(sessionState).toString()
       val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
       val stmt = connection.createStatement()


### PR DESCRIPTION
…getUser

## What changes were proposed in this pull request?

update the function name mismatch. 

## How was this patch tested?

manually test
