### PR TITLE
[SPARK-LLAP-160] Consider connection pooling to reuse connections to HS2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ dependencyOverrides += "org.codehaus.jackson" % "jackson-jaxrs" % "1.9.13"
 dependencyOverrides += "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13"
 dependencyOverrides += "org.codehaus.jackson" % "jackson-xc" % "1.9.13"
 dependencyOverrides += "org.apache.commons" % "commons-lang3" % "3.4"
+libraryDependencies += "org.apache.commons" % "commons-dbcp2" % "2.1"
 
 
 // Assembly rules for shaded JAR

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -20,11 +20,13 @@ package com.hortonworks.spark.sql.hive.llap
 import java.net.URI
 import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet, ResultSetMetaData,
   SQLException}
+import java.util.Properties
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.commons.dbcp2.BasicDataSource
+import org.apache.commons.dbcp2.BasicDataSourceFactory
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 import org.apache.hadoop.hive.serde2.typeinfo._
@@ -179,27 +181,28 @@ class JDBCWrapper {
       case Some(d) =>
         d.getConnection
       case None =>
-        val datasource = new BasicDataSource
-        datasource.setDriverClassName(driverClass.getCanonicalName)
-        datasource.setUrl(url)
-        datasource.setUsername(userName)
-        // for hdp older version support without dbcp2 configurations
+        val properties = new Properties()
+        // for older version of HDP which do not have dbcp2 configurations
         if (dbcp2Configs == null) {
-          datasource.setInitialSize(1)
-          datasource.setMaxConnLifetimeMillis(5000)
-          datasource.setMaxTotal(20)
-          datasource.setMaxIdle(10)
-          datasource.setMaxWaitMillis(4000)
+          properties.setProperty("initialSize", "1")
+          properties.setProperty("maxConnLifetimeMillis", "5000")
+          properties.setProperty("maxTotal", "40")
+          properties.setProperty("maxIdle", "10")
+          properties.setProperty("maxWaitMillis", "2000")
         } else {
           dbcp2Configs.split(" ").map(s => s.trim.split(":")).foreach {
             conf =>
-              datasource.addConnectionProperty(conf(0), conf(1))
+              properties.setProperty(conf(0), conf(1))
               log.debug(conf(0) + ":" + conf(1))
           }
         }
-        datasource.setPassword("password")
-        connectionPools.put(userName, datasource)
-        datasource.getConnection
+        properties.setProperty("driverClassName", driverClass.getCanonicalName)
+        properties.setProperty("url", url)
+        properties.setProperty("password", "password")
+        properties.setProperty("username", userName)
+        val dataSource = BasicDataSourceFactory.createDataSource(properties)
+        connectionPools.put(userName, dataSource)
+        dataSource.getConnection
     }
   }
 

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -185,7 +185,7 @@ class JDBCWrapper {
         // for older version of HDP which do not have dbcp2 configurations
         if (dbcp2Configs == null) {
           properties.setProperty("initialSize", "1")
-          properties.setProperty("maxConnLifetimeMillis", "5000")
+          properties.setProperty("maxConnLifetimeMillis", "10000")
           properties.setProperty("maxTotal", "40")
           properties.setProperty("maxIdle", "10")
           properties.setProperty("maxWaitMillis", "2000")

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -185,10 +185,10 @@ class JDBCWrapper {
         // for older version of HDP which do not have dbcp2 configurations
         if (dbcp2Configs == null) {
           properties.setProperty("initialSize", "1")
-          properties.setProperty("maxConnLifetimeMillis", "10000")
+          properties.setProperty("maxConnLifetimeMillis", "100000")
           properties.setProperty("maxTotal", "40")
           properties.setProperty("maxIdle", "10")
-          properties.setProperty("maxWaitMillis", "2000")
+          properties.setProperty("maxWaitMillis", "30000")
         } else {
           dbcp2Configs.split(" ").map(s => s.trim.split(":")).foreach {
             conf =>

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -18,13 +18,14 @@
 package com.hortonworks.spark.sql.hive.llap
 
 import java.net.URI
-import java.sql.Connection
+import java.sql.{Connection, SQLException}
 import java.util.UUID
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.llap.{LlapInputSplit, LlapRowInputFormat, Schema}
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapred.{InputSplit, JobConf}
+import org.apache.hive.service.cli.HiveSQLException
 
 import org.apache.spark.rdd.HadoopRDD
 import org.apache.spark.rdd.RDD
@@ -165,12 +166,18 @@ case class LlapRelation(
   private def handleCountStar(queryString: String): RDD[Row] = {
     tryWithResource(getConnection()) { conn =>
       tryWithResource(conn.createStatement()) { stmt =>
-        val rs = stmt.executeQuery(queryString)
-        if (rs.next()) {
-          val countStarValue = rs.getLong(1)
-          sqlContext.sparkContext.parallelize(1L to countStarValue).map(_ => Row.empty)
-        } else {
-          throw new IllegalStateException("Failed to read count star value")
+        try {
+          val rs = stmt.executeQuery(queryString)
+          if (rs.next()) {
+            val countStarValue = rs.getLong(1)
+            sqlContext.sparkContext.parallelize(1L to countStarValue).map(_ => Row.empty)
+          } else {
+            throw new IllegalStateException("Failed to read count star value")
+          }
+        } catch {
+            case e: Throwable => throw new SQLException(
+              e.toString.replace("shadehive.org.apache.hive.service.cli.HiveSQLException: ", ""))
+            case e: HiveSQLException => throw new HiveSQLException(e)
         }
       }
     }

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -47,7 +47,8 @@ case class LlapRelation(
   @transient val tableSchema: StructType = {
     val url = parameters("url")
     val user = parameters("user.name")
-    val conn = DefaultJDBCWrapper.getConnector(None, url, user)
+    val dbcp2Configs = parameters("dbcp2.conf")
+    val conn = DefaultJDBCWrapper.getConnector(None, url, user, dbcp2Configs)
     val queryKey = getQueryType()
 
     try {
@@ -129,7 +130,8 @@ case class LlapRelation(
   private def getConnection(): Connection = {
     val url = parameters("url")
     val user = parameters("user.name")
-    DefaultJDBCWrapper.getConnector(None, url, user)
+    val dbcp2Configs = parameters("dbcp2.conf")
+    DefaultJDBCWrapper.getConnector(None, url, user, dbcp2Configs)
   }
 
   private def getDbTableNames(nameStr: String): Tuple2[String, String] = {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -34,9 +34,11 @@ class DefaultSource extends RelationProvider {
       invoke(sessionState, sqlContext.sparkSession).toString()
     val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
+    val dbcp2Config = sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
     val params = parameters +
       ("user.name" -> user) +
       ("user.password" -> "password") +
+      ("dbcp2.conf" -> dbcp2Config) +
       ("url" -> connectionUrl)
 
     LlapRelation(

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -80,7 +80,8 @@ private[spark] class LlapExternalCatalog(
     val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
     val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
-    val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
+    val dbcp2Configs = sparkSession.sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
+    val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user, dbcp2Configs)
     connection
   }
 

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -102,7 +102,8 @@ private[sql] class LlapSessionCatalog(
       val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
       val getUserMethod = sessionState.getClass.getMethod("getUser")
       val user = getUserMethod.invoke(sessionState).toString()
-      val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
+      val dbcp2Configs = sparkSession.sqlContext.getConf("spark.sql.hive.llap.dbcp2", null)
+      val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user, dbcp2Configs)
       val stmt = connection.createStatement()
       stmt.executeUpdate(s"DESC `$db`.`$table`")
     }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestUtils.scala
@@ -24,8 +24,9 @@ object TestUtils {
   def updateConfWithMiniClusterSettings(
       spark: SparkSession,
       connectionUrl: String,
-      userName: String): Unit = {
-    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName)
+      userName: String,
+      dbcp2Confs : String): Unit = {
+    val conn = DefaultJDBCWrapper.getConnector(None, url = connectionUrl, userName, dbcp2Confs)
     val settings = Seq(
       "hive.llap.daemon.service.hosts",
       "hive.zookeeper.quorum",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use DBCP2 for creating the connection pool for each user.

## How was this patch tested?

Post the test results here. 
```
spark.sql.hive.llap.dbcp2 initialSize:2 maxTotal:200 maxIdle:100 maxConnLifetimeMillis:4000 maxWaitMillis:2000    

[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 3128.994s

spark.sql.hive.llap.dbcp2 initialSize:1 maxTotal:40 maxIdle:10 maxConnLifetimeMillis:5000 maxWaitMillis:2000

[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 3168.360s

OK
