### PR TITLE
[SPARK-LLAP-166] Remove JDK7 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ dist: trusty
 
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 cache:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Spark 2.2 removes Remove Java 7 support, this PR removes JDK7 from Travis CI, too.

## How was this patch tested?

Pass the Travis CI with only JDK8. This is irrelevant to test suite.

This closes #166 .