### PR TITLE
[SPARK-LLAP-169] Change JDBCWrapper.resolveQuery() to use LIMIT 0 rather than 1=0 for …

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -128,8 +128,9 @@ class JDBCWrapper {
   }
 
   def resolveQuery(conn: Connection, query: String): StructType = {
-    val rs = conn.prepareStatement(s"SELECT * FROM ($query) q WHERE 1=0").executeQuery()
-    log.debug(s"SELECT * FROM ($query) q WHERE 1=0")
+    val schemaQuery = s"SELECT * FROM ($query) q LIMIT 0"
+    val rs = conn.prepareStatement(schemaQuery).executeQuery()
+    log.debug(schemaQuery)
     try {
       val rsmd = rs.getMetaData
       val ncols = rsmd.getColumnCount


### PR DESCRIPTION
…faster 0-row result.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
