### PR TITLE
[SPARK-LLAP-171] Fix a function name typo at SparkSessionState.getUserNameString

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -32,7 +32,7 @@ class DefaultSource extends RelationProvider {
       getMethod("getConnectionUrl", classOf[SparkSession])
     val connectionUrl = getConnectionUrlMethod.
       invoke(sessionState, sqlContext.sparkSession).toString()
-    val getUserMethod = sessionState.getClass.getMethod("getUserString")
+    val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
     val params = parameters +
       ("user.name" -> user) +

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -78,7 +78,7 @@ private[spark] class LlapExternalCatalog(
     val getConnectionUrlMethod = sessionState.getClass.
       getMethod("getConnectionUrl", classOf[SparkSession])
     val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
-    val getUserMethod = sessionState.getClass.getMethod("getUserString")
+    val getUserMethod = sessionState.getClass.getMethod("getUser")
     val user = getUserMethod.invoke(sessionState).toString()
     val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
     connection

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -100,7 +100,7 @@ private[sql] class LlapSessionCatalog(
       val getConnectionUrlMethod = sessionState.getClass.
         getMethod("getConnectionUrl", classOf[SparkSession])
       val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
-      val getUserMethod = sessionState.getClass.getMethod("getUserString")
+      val getUserMethod = sessionState.getClass.getMethod("getUser")
       val user = getUserMethod.invoke(sessionState).toString()
       val connection = DefaultJDBCWrapper.getConnector(None, connectionUrl, user)
       val stmt = connection.createStatement()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This bug is brought from commit: 5b5ea71ecbede891fe4ca2427cfb7ef6c65958c7

update the getUser method name for matching the provided function name of Spark Internal side. 

The reason why it passed the test suite at that time.
(1) The reason is the mismatch between PR 5b5ea71ecbede891fe4ca2427cfb7ef6c65958c7  and test env setup. The PR do not synchronized on time. 

Are you sure whether the test result reported in the PR is correct with this patch?
(2) This PR is already in branch branch-2.2-HDP-2.6.2.0, and test via provided security test script and deployed to the QE team testing environment. It already passed the test as well. 

## How was this patch tested?

unit test passed. 
```
[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 3028.120s

OK

[root@ctr-e134-1499953498516-70977-01-000007 python]# ./spark-ranger-secure-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 611.721s