### PR TITLE
[SPARK-LLAP-156] Support LlapRelation table size property

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -187,6 +187,14 @@ case class LlapRelation(
     val resource = createResource
     try f.apply(resource) finally resource.close()
   }
+
+  override def sizeInBytes(): Long = {
+    if (parameters.isDefinedAt("sizeinbytes")) {
+      parameters("sizeinbytes").toLong
+    } else {
+      super.sizeInBytes
+    }
+  }
 }
 
 object LlapRelation {

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -71,12 +71,15 @@ private[sql] class LlapSessionCatalog(
           getMethod("getConnectionUrl", classOf[SparkSession])
         val connectionUrl = getConnectionUrlMethod.invoke(sessionState, sparkSession).toString()
 
+        val tableMeta = sessionState.catalog.getTableMetadata(TableIdentifier(table, Some(db)))
+        val sizeInBytes = tableMeta.stats.map(_.sizeInBytes.toLong).getOrElse(0L)
         val logicalRelation = LogicalRelation(
           DataSource(
             sparkSession = sparkSession,
             className = "org.apache.spark.sql.hive.llap",
             options = Map(
               "table" -> (metadata.database + "." + table),
+              "sizeinbytes" -> sizeInBytes.toString(),
               "url" -> connectionUrl)
           ).resolveRelation())
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This estimated table size would be used for optimizing the join plan. If the estimated size is not big, the broadcast join will be used. Thus, this PR is used to get the estimated table size from metadata s.t. computing optimized joined plan.  

## How was this patch tested?
```
[root@ctr-e134-1499953498516-99573-01-000002 python]# ./spark-ranger-secure-test.py TableTestSuite
.....................
----------------------------------------------------------------------
Ran 21 tests in 3011.014s

[root@ctr-e134-1499953498516-99573-01-000002 python]# ./spark-ranger-secure-test.py DbTestSuite
....
----------------------------------------------------------------------
Ran 4 tests in 612.001s
