### PR TITLE
[SPARK-LLAP-174] Add LlapQuery class to be able to run full queries from HS2/LLAP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("org.apache.hadoop.hive.common.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.conf.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.io.**" -> "shadehive.@0").inAll,
+  ShadeRule.rename("org.apache.hive.common.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hive.jdbc.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hive.service.**" -> "shadehive.@0").inAll,
   ShadeRule.rename("org.apache.hadoop.hive.metastore.**" -> "shadehive.@0").inAll,

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -132,7 +132,10 @@ class JDBCWrapper {
     }
   }
 
-  def resolveQuery(conn: Connection, query: String): StructType = {
+  def resolveQuery(conn: Connection, currentDatabase: String, query: String): StructType = {
+    if (currentDatabase != null) {
+      conn.prepareStatement(s"USE $currentDatabase").execute()
+    }
     val schemaQuery = s"SELECT * FROM ($query) q LIMIT 0"
     val rs = conn.prepareStatement(schemaQuery).executeQuery()
     log.debug(schemaQuery)

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQuery.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQuery.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.spark.sql.hive.llap
+
+import java.util.UUID
+
+import org.apache.hadoop.hive.llap.LlapBaseInputFormat
+
+import org.apache.spark.sql.{Dataset, Row, SQLContext}
+
+import org.slf4j.LoggerFactory
+
+class LlapQuery(val sc: SQLContext) {
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val handleIds = new scala.collection.mutable.HashSet[String]
+
+  private var currentDatabase: String = "default"
+
+  def setCurrentDatabase(dbName: String): Unit = {
+    currentDatabase = dbName
+  }
+
+  def sql(queryString: String): Dataset[Row] = {
+    val handleId = UUID.randomUUID().toString()
+    handleIds.add(handleId)
+    val df = sc.read
+      .format("org.apache.spark.sql.hive.llap")
+      .option("query", queryString)
+      .option("handleid", handleId)
+      .option("currentdatabase", currentDatabase)
+      .load()
+    df
+  }
+
+  def close(): Unit = {
+    handleIds.foreach ((handleId) => {
+      try {
+        LlapBaseInputFormat.close(handleId)
+      } catch {
+        case ex: Exception => {
+          log.error("Error closing " + handleId, ex)
+        }
+      }
+    })
+    handleIds.clear
+  }
+}

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapRelation.scala
@@ -22,7 +22,7 @@ import java.sql.{Connection, SQLException}
 import java.util.UUID
 
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.hive.llap.{LlapInputSplit, LlapRowInputFormat, Schema}
+import org.apache.hadoop.hive.llap.{LlapBaseInputFormat, LlapInputSplit, LlapRowInputFormat, Schema}
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapred.{InputSplit, JobConf}
 import org.apache.hive.service.cli.HiveSQLException
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation, PrunedFilteredScan}
 import org.apache.spark.sql.types.StructType
 
+import org.slf4j.LoggerFactory
 
 case class LlapRelation(
     @transient sc: SQLContext,
@@ -40,6 +41,8 @@ case class LlapRelation(
   extends BaseRelation
   with InsertableRelation
   with PrunedFilteredScan {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   override def sqlContext(): SQLContext = {
     sc
@@ -57,7 +60,11 @@ case class LlapRelation(
         val (dbName, tableName) = getDbTableNames(parameters("table"))
         DefaultJDBCWrapper.resolveTable(conn, dbName, tableName)
       } else {
-        DefaultJDBCWrapper.resolveQuery(conn, parameters("query"))
+        var currentDatabase: String = null
+        if (parameters.isDefinedAt("currentdatabase")) {
+          currentDatabase = parameters("currentdatabase")
+        }
+        DefaultJDBCWrapper.resolveQuery(conn, currentDatabase, parameters("query"))
       }
     } finally
     {
@@ -92,6 +99,9 @@ case class LlapRelation(
     val countStar = requiredColumns.isEmpty
     val queryString = getQueryString(requiredColumns, filters)
 
+    // If this was previously called, close any resources associated with the previous invocation
+    close()
+
     if (countStar) {
       handleCountStar(queryString)
     } else {
@@ -103,6 +113,12 @@ case class LlapRelation(
       jobConf.set("llap.if.query", queryString)
       jobConf.set("llap.if.user", parameters("user.name"))
       jobConf.set("llap.if.pwd", parameters("user.password"))
+      if (parameters.isDefinedAt("currentdatabase")) {
+        jobConf.set("llap.if.database", parameters("currentdatabase"))
+      }
+      if (parameters.isDefinedAt("handleid")) {
+        jobConf.set("llap.if.handleid", parameters("handleid"))
+      }
 
       // This should be set to the number of executors
       val numPartitions = sc.sparkContext.defaultMinPartitions
@@ -193,6 +209,22 @@ case class LlapRelation(
       parameters("sizeinbytes").toLong
     } else {
       super.sizeInBytes
+    }
+  }
+
+  def close(): Unit = {
+    if (parameters.isDefinedAt("handleid")) {
+      val handleId = parameters("handleid")
+      log.info("Closing handleid " + handleId)
+      try {
+        LlapBaseInputFormat.close(handleId)
+      } catch {
+        case ex: Exception => {
+          log.error("Error closing " + handleId, ex)
+        }
+      }
+    } else {
+      log.info("No handleid defined - cannot close handle")
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/DefaultSource.scala
@@ -27,7 +27,7 @@ class DefaultSource extends RelationProvider {
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String])
       : BaseRelation = {
-    val sessionState = SparkSession.getActiveSession.get.sessionState
+    val sessionState = sqlContext.sparkSession.sessionState
     val getConnectionUrlMethod = sessionState.getClass.
       getMethod("getConnectionUrl", classOf[SparkSession])
     val connectionUrl = getConnectionUrlMethod.

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapSessionCatalog.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.llap
 
 import java.sql.SQLException
+import java.util.UUID
 
 import com.hortonworks.spark.sql.hive.llap.DefaultJDBCWrapper
 import org.apache.hadoop.conf.Configuration
@@ -73,12 +74,15 @@ private[sql] class LlapSessionCatalog(
 
         val tableMeta = sessionState.catalog.getTableMetadata(TableIdentifier(table, Some(db)))
         val sizeInBytes = tableMeta.stats.map(_.sizeInBytes.toLong).getOrElse(0L)
+        // Add a handleID which can be used to close resources via LlapBaseInputFormat.close()
+        val handleId = UUID.randomUUID().toString()
         val logicalRelation = LogicalRelation(
           DataSource(
             sparkSession = sparkSession,
             className = "org.apache.spark.sql.hive.llap",
             options = Map(
               "table" -> (metadata.database + "." + table),
+              "handleid" -> handleId,
               "sizeinbytes" -> sizeInBytes.toString(),
               "url" -> connectionUrl)
           ).resolveRelation())


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add LlapQuery class to be able to run full queries from HS2/LLAP
- Add currentdatabase option to LlapRelation
- Use handleId so LlapBaseInputFormat resources can be closed