### PR TITLE
[SPARK-LLAP-188] Use Apache Spark 2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 
 name := "spark-llap"
-version := "1.1.4-2.2-SNAPSHOT"
+version := sys.props.getOrElse("version", "1.1.5-2.3-SNAPSHOT")
 organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
-sparkVersion := sys.props.getOrElse("spark.version", "2.2.0.2.6.4.0-91")
+sparkVersion := sys.props.getOrElse("spark.version", "2.3.0")
 
 val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3.2.6.4.0-91")
 val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.6.4.0-91")
@@ -79,6 +79,9 @@ libraryDependencies ++= Seq(
     .exclude("javax.servlet.jsp", "jsp-api")
     .exclude("javax.transaction", "jta")
     .exclude("javax.transaction", "transaction-api")
+    .exclude("org.eclipse.jetty", "jetty-annotations")
+    .exclude("org.eclipse.jetty", "jetty-runner")
+    .exclude("org.eclipse.jetty", "jetty-xml")
     .exclude("org.mortbay.jetty", "jetty")
     .exclude("org.mortbay.jetty", "jetty-util")
     .exclude("org.mortbay.jetty", "jetty-sslengine")

--- a/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/llap/LlapExternalCatalog.scala
@@ -27,14 +27,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hive.service.cli.HiveSQLException
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.hive.HiveExternalCatalog
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
 
 
@@ -382,9 +381,9 @@ private[spark] class LlapExternalCatalog(
     executeUpdate(s"ALTER TABLE $db.$oldName RENAME TO $db.$newName")
   }
 
-  override def alterTable(tableDefinition: CatalogTable): Unit = {
+  override def doAlterTable(tableDefinition: CatalogTable): Unit = {
     executeUpdate(s"ALTER TABLE ${tableDefinition.identifier.quotedString} TOUCH")
-    super.alterTable(tableDefinition)
+    super.doAlterTable(tableDefinition)
   }
 
   override def createPartitions(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recently, Apache Spark 2.3 is released offcially. This PR updates the dependency to Apache Spark 2.3.

## How was this patch tested?

Pass the Travis CI build test.

This closes #188 .