### PR TITLE
[SPARK-LLAP-196] Explicitly run tests via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ install:
   - build/sbt assembly
 
 script:
+  - build/sbt test
   - build/scalastyle


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to add `sbt test` to run the tests via Travis CI.

Seems we don't actually run the tests:

https://github.com/hortonworks-spark/spark-llap/blob/1683b3cc7bc107d44620af58292a37013c36e1c6/build.sbt#L149

## How was this patch tested?

This should be tested via Travis trigger.

Closes #196
