### PR TITLE
[SPARK-LLAP-200] Replace in with empty values to case when

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/FilterPushdown.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/FilterPushdown.scala
@@ -39,6 +39,11 @@ private[llap] object FilterPushdown extends Object {
     }
 
     def buildInClause(attr: String, values: Array[Any]): Option[String] = {
+      if (values.isEmpty) {
+        // See SPARK-18436. Values in `IN` can be empty but Hive can't handle this.
+        return Some(s"CASE WHEN ${attr} IS NULL THEN NULL ELSE FALSE END")
+      }
+
       getTypeForAttribute(schema, attr).map { dataType =>
         val valuesList = values.map(value => getSqlEscapedValue(dataType, value)).mkString(",")
         s"""$attr IN ($valuesList)"""

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestFilterPushdown.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestFilterPushdown.scala
@@ -115,6 +115,12 @@ class TestFilterPushdown extends FunSuite {
       "employee_id IN (88,89,90)")
   }
 
+  test("in - empty values are not allowed") {
+    checkFilter(employeeSchema,
+      In("employee_id", Array.empty),
+      "CASE WHEN employee_id IS NULL THEN NULL ELSE FALSE END")
+  }
+
   test("string starts with") {
     checkFilter(employeeSchema,
       StringStartsWith("management_role", "val"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR replaces `in` with empty values to `case when`. See also SPARK-18436.

## How was this patch tested?

Unit tests are added.

Closes #200