### PR TITLE
Update version in build.sbt and add Hive dependency for ParserUtils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,17 @@
 
 name := "spark-llap"
-version := sys.props.getOrElse("version", "1.1.5-2.3-SNAPSHOT")
+//<ownVersion>-<sparkVersion>-<hiveVersion>
+version := sys.props.getOrElse("version", "1.2-2.3-3.0-SNAPSHOT")
 organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
 sparkVersion := sys.props.getOrElse("spark.version", "2.3.0")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3.2.6.4.0-91")
-val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.6.4.0-91")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.0.0")
+val hiveVersion = sys.props.getOrElse("hive.version", "3.0.0")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
-val tezVersion = sys.props.getOrElse("tez.version", "0.8.4")
+val tezVersion = sys.props.getOrElse("tez.version", "0.9.1")
 val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")
 val repoUrl = sys.props.getOrElse("repourl", "https://repo1.maven.org/maven2/")
 
@@ -29,7 +30,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-catalyst" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided" force(),
-  "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force(),
+  ("org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force())
+    .exclude("org.apache.hive", "hive-exec"),
   "org.apache.spark" %% "spark-yarn" % testSparkVersion.value % "provided" force(),
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5" % "compile",
   "jline" % "jline" % "2.12.1" % "compile",
@@ -38,6 +40,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % scalatestVersion % "test",
 
   ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "provided")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("javax.servlet", "servlet-api")
     .exclude("stax", "stax-api")
     .exclude("org.apache.avro", "avro")
@@ -46,6 +49,7 @@ libraryDependencies ++= Seq(
     .exclude("commons-logging", "commons-logging"),
 
   ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")
@@ -109,6 +113,56 @@ libraryDependencies ++= Seq(
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging")
+    .exclude("io.netty", "netty-buffer")
+    .exclude("io.netty", "netty-common"),
+//Use ParserUtils to validate generated HiveQl strings in tests
+  ("org.apache.hive" % "hive-exec" % hiveVersion % "test")
+    .exclude("ant", "ant")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
+    .exclude("org.apache.ant", "ant")
+    .exclude("org.apache.avro", "avro")
+    .exclude("org.apache.curator", "apache-curator")
+    .exclude("org.apache.logging.log4j", "log4j-1.2-api")
+    .exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+    .exclude("org.apache.logging.log4j", "log4j-web")
+    .exclude("org.apache.slider", "slider-core")
+    .exclude("stax", "stax-api")
+    .exclude("javax.servlet", "jsp-api")
+    .exclude("javax.servlet", "servlet-api")
+    .exclude("javax.servlet.jsp", "jsp-api")
+    .exclude("javax.transaction", "jta")
+    .exclude("javax.transaction", "transaction-api")
+    .exclude("org.eclipse.jetty", "jetty-annotations")
+    .exclude("org.eclipse.jetty", "jetty-runner")
+    .exclude("org.eclipse.jetty", "jetty-xml")
+    .exclude("org.mortbay.jetty", "jetty")
+    .exclude("org.mortbay.jetty", "jetty-util")
+    .exclude("org.mortbay.jetty", "jetty-sslengine")
+    .exclude("org.mortbay.jetty", "jsp-2.1")
+    .exclude("org.mortbay.jetty", "jsp-api-2.1")
+    .exclude("org.mortbay.jetty", "servlet-api-2.5")
+    .exclude("org.datanucleus", "datanucleus-api-jdo")
+    .exclude("org.datanucleus", "datanucleus-core")
+    .exclude("org.datanucleus", "datanucleus-rdbms")
+    .exclude("org.datanucleus", "javax.jdo")
+    .exclude("org.apache.hadoop", "hadoop-client")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-app")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-common")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-shuffle")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-jobclient")
+    .exclude("org.apache.hadoop", "hadoop-distcp")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-resourcemanager")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-common")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
+    .exclude("org.apache.hadoop", "hadoop-common")
+    .exclude("org.apache.hadoop", "hadoop-hdfs")
+    .exclude("org.apache.hbase", "*")
+    .exclude("commons-beanutils", "commons-beanutils-core")
+    .exclude("commons-collections", "commons-collections")
+    .exclude("commons-logging", "commons-logging") 
+    .exclude("io.netty", "netty-buffer")
+    .exclude("io.netty", "netty-common")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.10"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update versions in build.sbt and add Hive dependency for ParserUtils

## How was this patch tested?

Build succeeds.
The commit bootstraps a new code line.
Please ignore the test failures. It can't find Hive 3.0 in Maven Central, so we're having to resolve it from our local build for now.