### PR TITLE
[SPARK-LLAP-208] DataFrames from HS2 to Driver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,16 @@
 
 name := "spark-llap"
-//<ownVersion>-<sparkVersion>-<hiveVersion>
-version := sys.props.getOrElse("version", "1.2-2.3-3.0-SNAPSHOT")
+version := sys.props.getOrElse("version", "1.1.5-2.3-SNAPSHOT")
 organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
 sparkVersion := sys.props.getOrElse("spark.version", "2.3.0")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.0.0")
-val hiveVersion = sys.props.getOrElse("hive.version", "3.0.0")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3.2.6.4.0-91")
+val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.6.4.0-91")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
-val tezVersion = sys.props.getOrElse("tez.version", "0.9.1")
+val tezVersion = sys.props.getOrElse("tez.version", "0.8.4")
 val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")
 val repoUrl = sys.props.getOrElse("repourl", "https://repo1.maven.org/maven2/")
 
@@ -30,8 +29,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-catalyst" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided" force(),
-  ("org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force())
-    .exclude("org.apache.hive", "hive-exec"),
+  "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-yarn" % testSparkVersion.value % "provided" force(),
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5" % "compile",
   "jline" % "jline" % "2.12.1" % "compile",
@@ -40,7 +38,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % scalatestVersion % "test",
 
   ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "provided")
-    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("javax.servlet", "servlet-api")
     .exclude("stax", "stax-api")
     .exclude("org.apache.avro", "avro")
@@ -49,7 +46,6 @@ libraryDependencies ++= Seq(
     .exclude("commons-logging", "commons-logging"),
 
   ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
-    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")
@@ -113,56 +109,6 @@ libraryDependencies ++= Seq(
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging")
-    .exclude("io.netty", "netty-buffer")
-    .exclude("io.netty", "netty-common"),
-//Use ParserUtils to validate generated HiveQl strings in tests
-  ("org.apache.hive" % "hive-exec" % hiveVersion % "test")
-    .exclude("ant", "ant")
-    .exclude("com.fasterxml.jackson.core", "jackson-databind")
-    .exclude("org.apache.ant", "ant")
-    .exclude("org.apache.avro", "avro")
-    .exclude("org.apache.curator", "apache-curator")
-    .exclude("org.apache.logging.log4j", "log4j-1.2-api")
-    .exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
-    .exclude("org.apache.logging.log4j", "log4j-web")
-    .exclude("org.apache.slider", "slider-core")
-    .exclude("stax", "stax-api")
-    .exclude("javax.servlet", "jsp-api")
-    .exclude("javax.servlet", "servlet-api")
-    .exclude("javax.servlet.jsp", "jsp-api")
-    .exclude("javax.transaction", "jta")
-    .exclude("javax.transaction", "transaction-api")
-    .exclude("org.eclipse.jetty", "jetty-annotations")
-    .exclude("org.eclipse.jetty", "jetty-runner")
-    .exclude("org.eclipse.jetty", "jetty-xml")
-    .exclude("org.mortbay.jetty", "jetty")
-    .exclude("org.mortbay.jetty", "jetty-util")
-    .exclude("org.mortbay.jetty", "jetty-sslengine")
-    .exclude("org.mortbay.jetty", "jsp-2.1")
-    .exclude("org.mortbay.jetty", "jsp-api-2.1")
-    .exclude("org.mortbay.jetty", "servlet-api-2.5")
-    .exclude("org.datanucleus", "datanucleus-api-jdo")
-    .exclude("org.datanucleus", "datanucleus-core")
-    .exclude("org.datanucleus", "datanucleus-rdbms")
-    .exclude("org.datanucleus", "javax.jdo")
-    .exclude("org.apache.hadoop", "hadoop-client")
-    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-app")
-    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-common")
-    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-shuffle")
-    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-jobclient")
-    .exclude("org.apache.hadoop", "hadoop-distcp")
-    .exclude("org.apache.hadoop", "hadoop-yarn-server-resourcemanager")
-    .exclude("org.apache.hadoop", "hadoop-yarn-server-common")
-    .exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
-    .exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
-    .exclude("org.apache.hadoop", "hadoop-common")
-    .exclude("org.apache.hadoop", "hadoop-hdfs")
-    .exclude("org.apache.hbase", "*")
-    .exclude("commons-beanutils", "commons-beanutils-core")
-    .exclude("commons-collections", "commons-collections")
-    .exclude("commons-logging", "commons-logging") 
-    .exclude("io.netty", "netty-buffer")
-    .exclude("io.netty", "netty-common")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.10"

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,17 @@
 
 name := "spark-llap"
-version := sys.props.getOrElse("version", "1.1.5-2.3-SNAPSHOT")
+//<ownVersion>-<sparkVersion>-<hiveVersion>
+version := sys.props.getOrElse("version", "1.2-2.3-3.0-SNAPSHOT")
 organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
 sparkVersion := sys.props.getOrElse("spark.version", "2.3.0")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "2.7.3.2.6.4.0-91")
-val hiveVersion = sys.props.getOrElse("hive.version", "2.1.0.2.6.4.0-91")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.0.0")
+val hiveVersion = sys.props.getOrElse("hive.version", "3.0.0")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
-val tezVersion = sys.props.getOrElse("tez.version", "0.8.4")
+val tezVersion = sys.props.getOrElse("tez.version", "0.9.1")
 val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")
 val repoUrl = sys.props.getOrElse("repourl", "https://repo1.maven.org/maven2/")
 
@@ -29,7 +30,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-catalyst" % testSparkVersion.value % "provided" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided" force(),
-  "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force(),
+  ("org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided" force())
+    .exclude("org.apache.hive", "hive-exec"),
   "org.apache.spark" %% "spark-yarn" % testSparkVersion.value % "provided" force(),
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5" % "compile",
   "jline" % "jline" % "2.12.1" % "compile",
@@ -38,6 +40,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % scalatestVersion % "test",
 
   ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % "provided")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("javax.servlet", "servlet-api")
     .exclude("stax", "stax-api")
     .exclude("org.apache.avro", "avro")
@@ -46,6 +49,7 @@ libraryDependencies ++= Seq(
     .exclude("commons-logging", "commons-logging"),
 
   ("org.apache.hadoop" % "hadoop-yarn-registry" % hadoopVersion % "provided")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
     .exclude("commons-beanutils", "commons-beanutils")
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("javax.servlet", "servlet-api")
@@ -109,6 +113,56 @@ libraryDependencies ++= Seq(
     .exclude("commons-beanutils", "commons-beanutils-core")
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging")
+    .exclude("io.netty", "netty-buffer")
+    .exclude("io.netty", "netty-common"),
+//Use ParserUtils to validate generated HiveQl strings in tests
+  ("org.apache.hive" % "hive-exec" % hiveVersion % "test")
+    .exclude("ant", "ant")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
+    .exclude("org.apache.ant", "ant")
+    .exclude("org.apache.avro", "avro")
+    .exclude("org.apache.curator", "apache-curator")
+    .exclude("org.apache.logging.log4j", "log4j-1.2-api")
+    .exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+    .exclude("org.apache.logging.log4j", "log4j-web")
+    .exclude("org.apache.slider", "slider-core")
+    .exclude("stax", "stax-api")
+    .exclude("javax.servlet", "jsp-api")
+    .exclude("javax.servlet", "servlet-api")
+    .exclude("javax.servlet.jsp", "jsp-api")
+    .exclude("javax.transaction", "jta")
+    .exclude("javax.transaction", "transaction-api")
+    .exclude("org.eclipse.jetty", "jetty-annotations")
+    .exclude("org.eclipse.jetty", "jetty-runner")
+    .exclude("org.eclipse.jetty", "jetty-xml")
+    .exclude("org.mortbay.jetty", "jetty")
+    .exclude("org.mortbay.jetty", "jetty-util")
+    .exclude("org.mortbay.jetty", "jetty-sslengine")
+    .exclude("org.mortbay.jetty", "jsp-2.1")
+    .exclude("org.mortbay.jetty", "jsp-api-2.1")
+    .exclude("org.mortbay.jetty", "servlet-api-2.5")
+    .exclude("org.datanucleus", "datanucleus-api-jdo")
+    .exclude("org.datanucleus", "datanucleus-core")
+    .exclude("org.datanucleus", "datanucleus-rdbms")
+    .exclude("org.datanucleus", "javax.jdo")
+    .exclude("org.apache.hadoop", "hadoop-client")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-app")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-common")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-shuffle")
+    .exclude("org.apache.hadoop", "hadoop-mapreduce-client-jobclient")
+    .exclude("org.apache.hadoop", "hadoop-distcp")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-resourcemanager")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-common")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-applicationhistoryservice")
+    .exclude("org.apache.hadoop", "hadoop-yarn-server-web-proxy")
+    .exclude("org.apache.hadoop", "hadoop-common")
+    .exclude("org.apache.hadoop", "hadoop-hdfs")
+    .exclude("org.apache.hbase", "*")
+    .exclude("commons-beanutils", "commons-beanutils-core")
+    .exclude("commons-collections", "commons-collections")
+    .exclude("commons-logging", "commons-logging") 
+    .exclude("io.netty", "netty-buffer")
+    .exclude("io.netty", "netty-common")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.10"

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/DriverResultSet.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/DriverResultSet.java
@@ -1,0 +1,25 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.Dataset;
+
+
+import java.util.List;
+
+//Holder class for data return directly to the Driver from HS2
+public class DriverResultSet {
+
+    public DriverResultSet(List<Row> data, StructType schema) {
+       this.data = data;
+       this.schema = schema;
+    }
+
+    public List<Row> data;
+    public StructType schema;
+
+    public Dataset<Row> asDataFrame(SparkSession session) {
+      return session.createDataFrame(data, schema);
+    }
+}

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -17,14 +17,13 @@
 
 package com.hortonworks.spark.sql.hive.llap
 
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 import java.net.URI
-import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet, ResultSetMetaData,
-  SQLException}
+import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet, ResultSetMetaData, SQLException}
 import java.util.Properties
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.commons.dbcp2.BasicDataSource
 import org.apache.commons.dbcp2.BasicDataSourceFactory
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category
@@ -32,6 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.Pr
 import org.apache.hadoop.hive.serde2.typeinfo._
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
+import org.apache.spark.sql.{Row, RowFactory}
 
 object Utils {
   def classForName(className: String): Class[_] = {
@@ -130,10 +130,68 @@ class JDBCWrapper {
     }
   }
 
-  def resolveQuery(conn: Connection, currentDatabase: String, query: String): StructType = {
+  def populateSchemaFields(ncols: Int,
+                           rsmd: ResultSetMetaData,
+                           fields: Array[StructField]): Unit = {
+    var i = 0
+    while (i < ncols) {
+      // HIVE-11750 - ResultSetMetadata.getColumnName() has format tablename.columnname
+      // Hack to remove the table name
+      val columnName = rsmd.getColumnLabel(i + 1).split("\\.").last
+      val dataType = rsmd.getColumnType(i + 1)
+      val typeName = rsmd.getColumnTypeName(i + 1)
+      val fieldSize = rsmd.getPrecision(i + 1)
+      val fieldScale = rsmd.getScale(i + 1)
+      val isSigned = true
+      val nullable = rsmd.isNullable(i + 1) != ResultSetMetaData.columnNoNulls
+      val columnType = getCatalystType(dataType, typeName, fieldSize, fieldScale, isSigned)
+      fields(i) = StructField(columnName, columnType, nullable)
+      i = i + 1
+    }
+  }
+
+  //Used for executing statements directly from the Driver to HS2
+  //ResultSet size is limited to prevent Driver OOM
+  //Should not be used for processing of big data
+  //Useful for DDL stmts
+ def executeStmt(conn: Connection,
+                 currentDatabase: String,
+                 query: String,
+                 maxExecResults: Long): DriverResultSet = {
+    useDatabase(conn, currentDatabase)
+    val stmt = conn.prepareStatement(query)
+    stmt.setLargeMaxRows(maxExecResults)
+    val rs = stmt.executeQuery()
+    log.debug(query)
+    try {
+      val rsmd = rs.getMetaData
+      val ncols = rsmd.getColumnCount
+      val fields = new Array[StructField](ncols)
+      populateSchemaFields(ncols, rsmd, fields)
+      val schema = new StructType(fields)
+      val data = new java.util.ArrayList[Row]()
+      while(rs.next()) {
+        val rowData = new Array[Any](ncols)
+        for (j <- 0 to ncols - 1) {
+          rowData(j) = rs.getObject(j + 1)
+        }
+        val row = new GenericRow(rowData)
+        data.add(row)
+      }
+      return new DriverResultSet(data, schema)
+    } finally {
+      rs.close()
+    }
+  }
+
+  def useDatabase(conn: Connection, currentDatabase: String) {
     if (currentDatabase != null) {
       conn.prepareStatement(s"USE $currentDatabase").execute()
     }
+  }
+
+  def resolveQuery(conn: Connection, currentDatabase: String, query: String): StructType = {
+    useDatabase(conn, currentDatabase)
     val schemaQuery = s"SELECT * FROM ($query) q LIMIT 0"
     val rs = conn.prepareStatement(schemaQuery).executeQuery()
     log.debug(schemaQuery)
@@ -141,21 +199,7 @@ class JDBCWrapper {
       val rsmd = rs.getMetaData
       val ncols = rsmd.getColumnCount
       val fields = new Array[StructField](ncols)
-      var i = 0
-      while (i < ncols) {
-        // HIVE-11750 - ResultSetMetadata.getColumnName() has format tablename.columnname
-        // Hack to remove the table name
-        val columnName = rsmd.getColumnLabel(i + 1).split("\\.").last
-        val dataType = rsmd.getColumnType(i + 1)
-        val typeName = rsmd.getColumnTypeName(i + 1)
-        val fieldSize = rsmd.getPrecision(i + 1)
-        val fieldScale = rsmd.getScale(i + 1)
-        val isSigned = true
-        val nullable = rsmd.isNullable(i + 1) != ResultSetMetaData.columnNoNulls
-        val columnType = getCatalystType(dataType, typeName, fieldSize, fieldScale, isSigned)
-        fields(i) = StructField(columnName, columnType, nullable)
-        i = i + 1
-      }
+      populateSchemaFields(ncols, rsmd, fields)
       new StructType(fields)
     } finally {
       rs.close()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Produce HS2 ResultSets as DataFrames. Allows simple DDL like "show tables" to be 
executed by the Driver without any Executors.

This is needed because Spark won't talk to the Hive Metastore, so we need DDL to come through HS2.

Refactored a piece of code which was needed in two places into the method "populateSchemaFields"

## How was this patch tested?

manual tests on 19 node Hadoop cluster
