### PR TITLE
[SPARK-LLAP-209] Add jackson exclusions to fix SparkSession use in unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,8 @@ libraryDependencies ++= Seq(
     .exclude("org.apache.hadoop", "hadoop-yarn-api")
     .exclude("org.apache.hadoop", "hadoop-annotations")
     .exclude("org.apache.hadoop", "hadoop-auth")
-    .exclude("org.apache.hadoop", "hadoop-hdfs"),
+    .exclude("org.apache.hadoop", "hadoop-hdfs")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind"),
 
   ("org.apache.hive" % "hive-llap-ext-client" % hiveVersion)
     .exclude("ant", "ant")
@@ -116,7 +117,8 @@ libraryDependencies ++= Seq(
     .exclude("commons-collections", "commons-collections")
     .exclude("commons-logging", "commons-logging")
     .exclude("io.netty", "netty-buffer")
-    .exclude("io.netty", "netty-common"),
+    .exclude("io.netty", "netty-common")
+    .exclude("com.fasterxml.jackson.core", "jackson-databind"),
 //Use ParserUtils to validate generated HiveQl strings in tests
   ("org.apache.hive" % "hive-exec" % hiveVersion % "test")
     .exclude("ant", "ant")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add jackson exclusion in 1 Tez and 1 Hive module dependency

## How was this patch tested?

Existing unit tests succeed

```
[info] ScalaTest
[info] Run completed in 8 seconds, 262 milliseconds.
[info] Total number of tests run: 25
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 25, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 25, Failed 0, Errors 0, Passed 25
[success] Total time: 39 s, completed May 6, 2018 8:11:43 PM
```