### PR TITLE
[SPARK-LLAP-212] Add executeUpdate to HiveWarehouseSession API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,10 @@ libraryDependencies ++= Seq(
     .exclude("commons-logging", "commons-logging")
     .exclude("io.netty", "netty-buffer")
     .exclude("io.netty", "netty-common")
-    .exclude("com.fasterxml.jackson.core", "jackson-databind"),
+    .exclude("com.fasterxml.jackson.core", "jackson-databind")
+    .exclude("org.apache.arrow", "arrow-vector")
+    .exclude("org.apache.arrow", "arrow-format")
+    .exclude("org.apache.arrow", "arrow-memory"),
 //Use ParserUtils to validate generated HiveQl strings in tests
   ("org.apache.hive" % "hive-exec" % hiveVersion % "test")
     .exclude("ant", "ant")
@@ -167,6 +170,9 @@ libraryDependencies ++= Seq(
     .exclude("commons-logging", "commons-logging") 
     .exclude("io.netty", "netty-buffer")
     .exclude("io.netty", "netty-common")
+    .exclude("org.apache.arrow", "arrow-vector")
+    .exclude("org.apache.arrow", "arrow-format")
+    .exclude("org.apache.arrow", "arrow-memory")
 )
 dependencyOverrides += "com.google.guava" % "guava" % "16.0.1"
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.10"

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/CreateTableBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/CreateTableBuilder.java
@@ -70,7 +70,7 @@ public class CreateTableBuilder {
     }
 
     public void create() {
-        hive.exec(this.toString());
+        hive.executeUpdate(this.toString());
     }
 
     public String toString() {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSession.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSession.java
@@ -31,6 +31,8 @@ public interface HiveWarehouseSession {
     Dataset<Row> execute(String sql);
     Dataset<Row> exec(String sql);
 
+    boolean executeUpdate(String sql);
+
     Dataset<Row> table(String sql);
 
     SparkSession session();

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -150,10 +150,10 @@ class JDBCWrapper {
     }
   }
 
-  //Used for executing statements directly from the Driver to HS2
+  //Used for executing queries directly from the Driver to HS2
   //ResultSet size is limited to prevent Driver OOM
   //Should not be used for processing of big data
-  //Useful for DDL stmts
+  //Useful for DDL instrospection statements like 'show tables'
  def executeStmt(conn: Connection,
                  currentDatabase: String,
                  query: String,
@@ -182,6 +182,19 @@ class JDBCWrapper {
     } finally {
       rs.close()
     }
+  }
+
+  //Used for executing statements directly from the Driver to HS2
+  //with no results
+  //Useful for DDL statements like 'create table'
+  def executeUpdate(conn: Connection,
+                  currentDatabase: String,
+                  query: String): Boolean = {
+    useDatabase(conn, currentDatabase)
+    val stmt = conn.prepareStatement(query)
+    val succeed = stmt.execute()
+    log.debug(query)
+    succeed
   }
 
   def useDatabase(conn: Connection, currentDatabase: String) {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseSessionImpl.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseSessionImpl.java
@@ -49,6 +49,15 @@ class MockHiveWarehouseSessionImpl extends HiveWarehouseSessionImpl {
                         throw new RuntimeException(pe);
                     }
                 };
+      super.executeUpdate =
+        (conn, database, sql) -> {
+          try {
+            org.apache.hadoop.hive.ql.parse.ParseUtils.parse(sql);
+            return true;
+          } catch(ParseException pe) {
+            throw new RuntimeException(pe);
+          }
+        };
         HiveWarehouseSessionImpl.HIVE_WAREHOUSE_CONNECTOR_INTERNAL =
                 "com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector";
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add executeUpdate to API for raw sql create/update/delete/insert. 

Using the existing HiveWarehouseSession.execute(sql) will succeed in doing an update to Hive, but it will throw an exception to the client on JDBC close. "Caused by: java.sql.SQLException: The query did not generate a result set!"

Additionally, build began failing due to
```
[error] 1 error was encountered during merge
java.lang.RuntimeException: deduplicate: different file contents found in the following:
/Users/ewohlstadter/.ivy2/cache/org.apache.arrow/arrow-vector/jars/arrow-vector-0.8.0.jar:git.properties
/Users/ewohlstadter/.ivy2/cache/org.apache.arrow/arrow-format/jars/arrow-format-0.8.0.jar:git.properties
/Users/ewohlstadter/.ivy2/cache/org.apache.arrow/arrow-memory/jars/arrow-memory-0.8.0.jar:git.properties
```
adding exclusions removed the problem, although I'm not that familiar with ivy.

## How was this patch tested?

Modification to existing unit test