### PR TITLE
[SPARK-LLAP-216] Fix test cases to stop sessions to ensure listener is not added multiple times

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -17,21 +17,23 @@
 
 package com.hortonworks.spark.sql.hive.llap
 
-import org.apache.spark.sql.catalyst.expressions.GenericRow
 import java.net.URI
 import java.sql.{Connection, DatabaseMetaData, Driver, DriverManager, ResultSet, ResultSetMetaData, SQLException}
 import java.util.Properties
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.commons.dbcp2.BasicDataSource
 import org.apache.commons.dbcp2.BasicDataSourceFactory
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 import org.apache.hadoop.hive.serde2.typeinfo._
+import org.apache.spark.sql.{Row, RowFactory}
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
-import org.apache.spark.sql.{Row, RowFactory}
+
 
 object Utils {
   def classForName(className: String): Class[_] = {
@@ -150,10 +152,10 @@ class JDBCWrapper {
     }
   }
 
-  //Used for executing queries directly from the Driver to HS2
-  //ResultSet size is limited to prevent Driver OOM
-  //Should not be used for processing of big data
-  //Useful for DDL instrospection statements like 'show tables'
+  // Used for executing queries directly from the Driver to HS2
+  // ResultSet size is limited to prevent Driver OOM
+  // Should not be used for processing of big data
+  // Useful for DDL instrospection statements like 'show tables'
  def executeStmt(conn: Connection,
                  currentDatabase: String,
                  query: String,
@@ -184,9 +186,9 @@ class JDBCWrapper {
     }
   }
 
-  //Used for executing statements directly from the Driver to HS2
-  //with no results
-  //Useful for DDL statements like 'create table'
+  // Used for executing statements directly from the Driver to HS2
+  // with no results
+  // Useful for DDL statements like 'create table'
   def executeUpdate(conn: Connection,
                   currentDatabase: String,
                   query: String): Boolean = {

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
@@ -36,6 +36,10 @@ class LlapQueryExecutionListener extends QueryExecutionListener with Logging {
   }
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+    println
+    println(funcName)
+    println
+    println(qe.toString)
     closeLlapRelation(qe)
   }
 

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
@@ -36,10 +36,6 @@ class LlapQueryExecutionListener extends QueryExecutionListener with Logging {
   }
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
-    println
-    println(funcName)
-    println
-    println(qe.toString)
     closeLlapRelation(qe)
   }
 

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -53,11 +53,6 @@ class HiveWarehouseBuilderTest {
 
     @Test
     void testAllBuilderConfig() {
-        SparkSession session = SparkSession
-                .builder()
-                .master("local")
-                .appName("HiveWarehouseConnector test")
-                .getOrCreate();
         HiveWarehouseSessionState sessionState =
                 HiveWarehouseBuilder
                         .session(session)
@@ -79,11 +74,6 @@ class HiveWarehouseBuilderTest {
 
     @Test
     void testAllConfConfig() {
-        SparkSession session = SparkSession
-                .builder()
-                .master("local")
-                .appName("HiveWarehouseConnector test")
-                .getOrCreate();
         session.conf().set(HWConf.USER.qualifiedKey, TEST_USER);
         session.conf().set(HWConf.PASSWORD.qualifiedKey, TEST_PASSWORD);
         session.conf().set(HWConf.HS2_URL.qualifiedKey, TEST_HS2_URL);

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -18,6 +18,8 @@
 package com.hortonworks.spark.sql.hive.llap;
 
 import org.apache.spark.sql.SparkSession;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -30,6 +32,24 @@ class HiveWarehouseBuilderTest {
     static final String TEST_DBCP2_CONF = "defaultQueryTimeout=100";
     static final Long TEST_EXEC_RESULTS_MAX = Long.valueOf(12345L);
     static final String TEST_DEFAULT_DB = "default12345";
+
+    private transient SparkSession session = null;
+
+    @Before
+    public void setUp() {
+        // Trigger static initializer of TestData
+        session = SparkSession
+                .builder()
+                .master("local")
+                .appName("HiveWarehouseConnector test")
+                .getOrCreate();
+    }
+
+    @After
+    public void tearDown() {
+        session.stop();
+        session = null;
+    }
 
     @Test
     void testAllBuilderConfig() {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -33,7 +33,7 @@ class HiveWarehouseBuilderTest {
     static final Long TEST_EXEC_RESULTS_MAX = Long.valueOf(12345L);
     static final String TEST_DEFAULT_DB = "default12345";
 
-    private transient SparkSession session = null;
+    transient SparkSession session = null;
 
     @Before
     public void setUp() {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -37,7 +37,6 @@ class HiveWarehouseBuilderTest {
 
     @Before
     public void setUp() {
-        // Trigger static initializer of TestData
         session = SparkSession
                 .builder()
                 .master("local")

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -30,7 +30,7 @@ class HiveWarehouseSessionHiveQlTest {
     private HiveWarehouseSession hive;
     private int mockExecuteResultSize;
 
-    private transient SparkSession session = null;
+    transient SparkSession session = null;
 
     @Before
     void setup() {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -18,6 +18,7 @@
 package com.hortonworks.spark.sql.hive.llap;
 
 import org.apache.spark.sql.SparkSession;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +29,8 @@ class HiveWarehouseSessionHiveQlTest {
 
     private HiveWarehouseSession hive;
     private int mockExecuteResultSize;
+
+    private transient SparkSession session = null;
 
     @Before
     void setup() {
@@ -48,6 +51,12 @@ class HiveWarehouseSessionHiveQlTest {
          hive = new MockHiveWarehouseSessionImpl(sessionState);
          mockExecuteResultSize =
                  MockHiveWarehouseSessionImpl.testFixture().data.size();
+    }
+
+    @After
+    public void tearDown() {
+        session.stop();
+        session = null;
     }
 
     @Test

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -33,7 +33,7 @@ class HiveWarehouseSessionHiveQlTest {
     transient SparkSession session = null;
 
     @Before
-    void setup() {
+    void setUp() {
         session = SparkSession
                 .builder()
                 .master("local")

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -37,7 +37,7 @@ class HiveWarehouseSessionHiveQlTest {
         session = SparkSession
                 .builder()
                 .master("local")
-                .appName("HiveWarehouseConnector test")
+                .appName("HiveWarehouseSessionHiveQlTest test")
                 .getOrCreate();
         HiveWarehouseSessionState sessionState =
                 HiveWarehouseBuilder

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -34,7 +34,7 @@ class HiveWarehouseSessionHiveQlTest {
 
     @Before
     void setup() {
-        SparkSession session = SparkSession
+        session = SparkSession
                 .builder()
                 .master("local")
                 .appName("HiveWarehouseConnector test")

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -20,18 +20,18 @@ package com.hortonworks.spark.sql.hive.llap
 import org.scalatest.FunSuite
 
 class TestJavaProxy extends FunSuite {
-  test("HiveWarehouseBuilder") {
-    val builderTest = new HiveWarehouseBuilderTest();
-    builderTest.testAllBuilderConfig();
-  }
-
-  test("HiveWarehouseSession") {
-    val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
-    hiveWarehouseSessionTest.setup()
-    hiveWarehouseSessionTest.testCreateDatabase()
-    hiveWarehouseSessionTest.testCreateTable()
-    hiveWarehouseSessionTest.testExecuteQuery()
-    hiveWarehouseSessionTest.testSetDatabase()
-    hiveWarehouseSessionTest.testShowTable()
-  }
+//  test("HiveWarehouseBuilder") {
+//    val builderTest = new HiveWarehouseBuilderTest();
+//    builderTest.testAllBuilderConfig();
+//  }
+//
+//  test("HiveWarehouseSession") {
+//    val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
+//    hiveWarehouseSessionTest.setup()
+//    hiveWarehouseSessionTest.testCreateDatabase()
+//    hiveWarehouseSessionTest.testCreateTable()
+//    hiveWarehouseSessionTest.testExecuteQuery()
+//    hiveWarehouseSessionTest.testSetDatabase()
+//    hiveWarehouseSessionTest.testShowTable()
+//  }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -20,18 +20,18 @@ package com.hortonworks.spark.sql.hive.llap
 import org.scalatest.FunSuite
 
 class TestJavaProxy extends FunSuite {
-//  test("HiveWarehouseBuilder") {
-//    val builderTest = new HiveWarehouseBuilderTest();
-//    builderTest.testAllBuilderConfig();
-//  }
-//
-//  test("HiveWarehouseSession") {
-//    val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
-//    hiveWarehouseSessionTest.setup()
-//    hiveWarehouseSessionTest.testCreateDatabase()
-//    hiveWarehouseSessionTest.testCreateTable()
-//    hiveWarehouseSessionTest.testExecuteQuery()
-//    hiveWarehouseSessionTest.testSetDatabase()
-//    hiveWarehouseSessionTest.testShowTable()
-//  }
+  test("HiveWarehouseBuilder") {
+    val builderTest = new HiveWarehouseBuilderTest();
+    builderTest.testAllBuilderConfig();
+  }
+
+  test("HiveWarehouseSession") {
+    val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
+    hiveWarehouseSessionTest.setup()
+    hiveWarehouseSessionTest.testCreateDatabase()
+    hiveWarehouseSessionTest.testCreateTable()
+    hiveWarehouseSessionTest.testExecuteQuery()
+    hiveWarehouseSessionTest.testSetDatabase()
+    hiveWarehouseSessionTest.testShowTable()
+  }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -34,7 +34,7 @@ class TestJavaProxy extends FunSuite {
     val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
 
     def setupAndTearDown(test: () => Unit): Unit = try {
-      hiveWarehouseSessionTest.setup()
+      hiveWarehouseSessionTest.setUp()
       test()
     } finally {
       hiveWarehouseSessionTest.tearDown()

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -21,17 +21,29 @@ import org.scalatest.FunSuite
 
 class TestJavaProxy extends FunSuite {
   test("HiveWarehouseBuilder") {
-    val builderTest = new HiveWarehouseBuilderTest();
-    builderTest.testAllBuilderConfig();
+    val builderTest = new HiveWarehouseBuilderTest()
+    try {
+      builderTest.setUp()
+      builderTest.testAllBuilderConfig()
+    } finally {
+      builderTest.tearDown()
+    }
   }
 
   test("HiveWarehouseSession") {
     val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
-    hiveWarehouseSessionTest.setup()
-    hiveWarehouseSessionTest.testCreateDatabase()
-    hiveWarehouseSessionTest.testCreateTable()
-    hiveWarehouseSessionTest.testExecuteQuery()
-    hiveWarehouseSessionTest.testSetDatabase()
-    hiveWarehouseSessionTest.testShowTable()
+
+    def setupAndTearDown(test: () => Unit): Unit = try {
+      hiveWarehouseSessionTest.setup()
+      test()
+    } finally {
+      hiveWarehouseSessionTest.tearDown()
+    }
+
+    setupAndTearDown(hiveWarehouseSessionTest.testCreateDatabase)
+    setupAndTearDown(hiveWarehouseSessionTest.testCreateTable)
+    setupAndTearDown(hiveWarehouseSessionTest.testExecuteQuery)
+    setupAndTearDown(hiveWarehouseSessionTest.testSetDatabase)
+    setupAndTearDown(hiveWarehouseSessionTest.testShowTable)
   }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -33,17 +33,17 @@ class TestJavaProxy extends FunSuite {
   test("HiveWarehouseSession") {
     val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
 
-    def setupAndTearDown(test: () => Unit): Unit = try {
+    def withSetUpAndTearDown(test: () => Unit): Unit = try {
       hiveWarehouseSessionTest.setUp()
       test()
     } finally {
       hiveWarehouseSessionTest.tearDown()
     }
 
-    setupAndTearDown(hiveWarehouseSessionTest.testCreateDatabase)
-    setupAndTearDown(hiveWarehouseSessionTest.testCreateTable)
-    setupAndTearDown(hiveWarehouseSessionTest.testExecuteQuery)
-    setupAndTearDown(hiveWarehouseSessionTest.testSetDatabase)
-    setupAndTearDown(hiveWarehouseSessionTest.testShowTable)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateDatabase)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateTable)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testExecuteQuery)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testSetDatabase)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testShowTable)
   }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
@@ -60,6 +60,7 @@ class TestLlapQueryExecutionListener
   test("Closes all LlapRelations after query executions - basic") {
     val df = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     assert(CloseCalls.closeCalls.get() == 0)
+    df.explain(true)
     df.collect()
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
@@ -70,6 +71,7 @@ class TestLlapQueryExecutionListener
     val df3 = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     val unionDF = df1.union(df2).union(df3)
     assert(CloseCalls.closeCalls.get() == 0)
+    unionDF.explain(true)
     unionDF.collect()
     assert(
       CloseCalls.closeCalls.get() == 3,
@@ -81,6 +83,7 @@ class TestLlapQueryExecutionListener
     val df2 = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     val unionDF = df1.union(df1).union(df2)
     assert(CloseCalls.closeCalls.get() == 0)
+    unionDF.explain(true)
     unionDF.show(0)
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
@@ -93,6 +96,7 @@ class TestLlapQueryExecutionListener
     val df = spark.sql("SELECT * FROM tableA")
     assert(CloseCalls.closeCalls.get() == 0)
     df.count()
+    df.explain(true)
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
@@ -60,7 +60,6 @@ class TestLlapQueryExecutionListener
   test("Closes all LlapRelations after query executions - basic") {
     val df = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     assert(CloseCalls.closeCalls.get() == 0)
-    df.explain(true)
     df.collect()
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
@@ -71,7 +70,6 @@ class TestLlapQueryExecutionListener
     val df3 = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     val unionDF = df1.union(df2).union(df3)
     assert(CloseCalls.closeCalls.get() == 0)
-    unionDF.explain(true)
     unionDF.collect()
     assert(
       CloseCalls.closeCalls.get() == 3,
@@ -83,7 +81,6 @@ class TestLlapQueryExecutionListener
     val df2 = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     val unionDF = df1.union(df1).union(df2)
     assert(CloseCalls.closeCalls.get() == 0)
-    unionDF.explain(true)
     unionDF.show(0)
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
@@ -96,7 +93,6 @@ class TestLlapQueryExecutionListener
     val df = spark.sql("SELECT * FROM tableA")
     assert(CloseCalls.closeCalls.get() == 0)
     df.count()
-    df.explain(true)
     assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
   }
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestLlapQueryExecutionListener.scala
@@ -61,7 +61,7 @@ class TestLlapQueryExecutionListener
     val df = spark.read.format(classOf[FakeDefaultSource].getCanonicalName).load()
     assert(CloseCalls.closeCalls.get() == 0)
     df.collect()
-    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
+    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation should only be attempted once.")
   }
 
   test("Closes all LlapRelations after query executions - union") {
@@ -82,7 +82,7 @@ class TestLlapQueryExecutionListener
     val unionDF = df1.union(df1).union(df2)
     assert(CloseCalls.closeCalls.get() == 0)
     unionDF.show(0)
-    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
+    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation should only be attempted once.")
   }
 
   test("Closes all LlapRelations after query executions - SQL") {
@@ -93,7 +93,7 @@ class TestLlapQueryExecutionListener
     val df = spark.sql("SELECT * FROM tableA")
     assert(CloseCalls.closeCalls.get() == 0)
     df.count()
-    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation was not attempted.")
+    assert(CloseCalls.closeCalls.get() == 1, "Closing LlapRelation should only be attempted once.")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to fix some tests to stop the spark session so that it adds the query execution listener once.

## How was this patch tested?

Tests were fixed.

Closes #216 