### PR TITLE
[SPARK-LLAP-218] Don't log expired connections

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -250,6 +250,7 @@ class JDBCWrapper {
           properties.setProperty("maxTotal", "40")
           properties.setProperty("maxIdle", "10")
           properties.setProperty("maxWaitMillis", "30000")
+          properties.setProperty("logExpiredConnections", "false")
         } else {
           dbcp2Configs.split(" ").map(s => s.trim.split(":")).foreach {
             conf =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't log the warnings from DBCP2 about expired connections

## How was this patch tested?

```
scala> hive.dropTable(tempTable, true, false)
```
was consistently triggering the warning to be logged on the console. 
After making the change, I don't see it anymore.