### PR TITLE
[SPARK-LLAP-221] Add Python testing environment to Travis and  Python version of HiveWarehouseSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/*.jar
 derby.log
 metastore_db/
 target/
+*.pyc
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ metastore_db/
 target/
 *.pyc
 .coverage
+python/dist/
+python/pyspark_llap.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_install:
 
 install:
   - build/sbt assembly -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
-  # sbt test:assembly generates a jar containing test classes complied. This is required to run the Python tests.
+  # sbt test:package generates a jar containing test classes complied. This is required to run the Python tests.
   - build/sbt test:package -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,16 @@
 sudo: required
 dist: trusty
 
-language: java
-jdk:
-  - oraclejdk8
+language: python
+
+matrix:
+  include:
+    # Spark 2.3.0
+    - jdk: oraclejdk8
+      python: 2.7
+      env: >
+        TEST_SPARK_VERSION=2.3.0
+        SPARK_HOME=$TRAVIS_BUILD_DIR/spark/spark-$TEST_SPARK_VERSION-bin-hadoop2.7
 
 cache:
   directories:
@@ -28,9 +35,27 @@ cache:
 notifications:
   email: false
 
+before_install:
+  # Download Python packages.
+  - pip install coverage pycodestyle
+  # Download Spark
+  - mkdir $TRAVIS_BUILD_DIR/spark
+  - curl -O http://mirrors.gigenet.com/apache/spark/spark-$TEST_SPARK_VERSION/spark-$TEST_SPARK_VERSION-bin-hadoop2.7.tgz
+  - tar zxfC spark-$TEST_SPARK_VERSION-bin-hadoop2.7.tgz $TRAVIS_BUILD_DIR/spark
+  - export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=:; echo "${ZIPS[*]}"):$PYTHONPATH
+  - export PYTHONPATH=`pwd`/python:$PYTHONPATH
+
 install:
   - build/sbt assembly -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
+  # sbt test:assembly generates a jar containing test classes complied. This is required to run the Python tests.
+  - build/sbt test:package -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
 
 script:
+  # Scala / Java
   - build/sbt test -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
   - build/scalastyle
+  # Python
+  - coverage run python/pyspark_llap/sql/tests.py
+  - coverage report --include "python/pyspark_llap/*" --show-missing
+  - pycodestyle `find python/pyspark_llap -name *.py` --ignore=E402,E731,E241,W503,E226,E722,E741,E305 --max-line-length=100
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,5 @@ script:
   - python setup.py sdist
   - coverage run pyspark_llap/sql/tests.py
   - coverage report --include "pyspark_llap/*" --show-missing
-  - pycodestyle `find pyspark_llap -name *.py` --ignore=E402,E731,E241,W503,E226,E722,E741,E305 --max-line-length=100
+  - pycodestyle `find . -name '*.py'` --ignore=E402,E731,E241,W503,E226,E722,E741,E305 --max-line-length=100
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,9 @@ script:
   - build/sbt test -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT
   - build/scalastyle
   # Python
-  - coverage run python/pyspark_llap/sql/tests.py
-  - coverage report --include "python/pyspark_llap/*" --show-missing
-  - pycodestyle `find python/pyspark_llap -name *.py` --ignore=E402,E731,E241,W503,E226,E722,E741,E305 --max-line-length=100
+  - cd python
+  - python setup.py sdist
+  - coverage run pyspark_llap/sql/tests.py
+  - coverage report --include "pyspark_llap/*" --show-missing
+  - pycodestyle `find pyspark_llap -name *.py` --ignore=E402,E731,E241,W503,E226,E722,E741,E305 --max-line-length=100
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       python: 2.7
       env: >
         TEST_SPARK_VERSION=2.3.0
-        SPARK_HOME=$TRAVIS_BUILD_DIR/spark/spark-$TEST_SPARK_VERSION-bin-hadoop2.7
 
 cache:
   directories:
@@ -36,14 +35,19 @@ notifications:
   email: false
 
 before_install:
+  - export PYTHONPATH=`pwd`/python:$PYTHONPATH
+  - export SPARK_HOME=$TRAVIS_BUILD_DIR/spark/spark-$TEST_SPARK_VERSION-bin-hadoop2.7
+
   # Download Python packages.
   - pip install coverage pycodestyle
+
   # Download Spark
   - mkdir $TRAVIS_BUILD_DIR/spark
   - curl -O http://mirrors.gigenet.com/apache/spark/spark-$TEST_SPARK_VERSION/spark-$TEST_SPARK_VERSION-bin-hadoop2.7.tgz
   - tar zxfC spark-$TEST_SPARK_VERSION-bin-hadoop2.7.tgz $TRAVIS_BUILD_DIR/spark
+
+  # Set the PySpark libraries paths for, for example, py4j and pyspark. This should be set after Spark is downloaded.
   - export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=:; echo "${ZIPS[*]}"):$PYTHONPATH
-  - export PYTHONPATH=`pwd`/python:$PYTHONPATH
 
 install:
   - build/sbt assembly -Drepourl=http://nexus-private.hortonworks.com/nexus/content/groups/public/ -Dhadoop.version=3.0.0.3.0.0.0-SNAPSHOT -Dhive.version=3.0.0.3.0.0.0-SNAPSHOT

--- a/python/pyspark_llap/__init__.py
+++ b/python/pyspark_llap/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark_llap/sql/__init__.py
+++ b/python/pyspark_llap/sql/__init__.py
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark_llap.sql.session import HiveWarehouseBuilder
+
+__all__ = ['HiveWarehouseBuilder']

--- a/python/pyspark_llap/sql/session.py
+++ b/python/pyspark_llap/sql/session.py
@@ -1,0 +1,202 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+
+if sys.version >= '3':
+    basestring = unicode = str
+    long = int
+
+from pyspark import SparkContext
+from pyspark.sql import SparkSession, DataFrame
+
+
+class HiveWarehouseBuilder(object):
+    """Builder for :class:`HiveWarehouseSession`."""
+
+    def __init__(self, spark_session, jhwbuilder):
+        self._spark_session = spark_session
+        self._jhwbuilder = jhwbuilder
+
+    @staticmethod
+    def session(session):
+        assert isinstance(session, SparkSession), "session should be a spark session"
+
+        jsparkSession = session._jsparkSession
+        jvm = session._jvm
+
+        return HiveWarehouseBuilder(
+            session,
+            jvm.com.hortonworks.spark.sql.hive.llap.HiveWarehouseBuilder.session(jsparkSession))
+
+    def userPassword(self, user, password):
+        assert isinstance(user, basestring), "user should be a string"
+        assert isinstance(password, basestring), "password should be a string"
+
+        self._jhwbuilder.userPassword(user, password)
+        return self
+
+    def hs2url(self, hs2url):
+        assert isinstance(hs2url, basestring), "hs2url should be a string"
+
+        self._jhwbuilder.hs2url(hs2url)
+        return self
+
+    def maxExecResults(self, maxExecResults):
+        assert isinstance(maxExecResults, int), "maxExecResults should be a number"
+
+        self._jhwbuilder.maxExecResults(maxExecResults)
+        return self
+
+    def dbcp2Conf(self, dbcp2Conf):
+        assert isinstance(dbcp2Conf, basestring), "dbcp2Conf should be a string"
+
+        self._jhwbuilder.dbcp2Conf(dbcp2Conf)
+        return self
+
+    def defaultDB(self, defaultDB):
+        assert isinstance(defaultDB, basestring), "defaultDB should be a string"
+
+        self._jhwbuilder.defaultDB(defaultDB)
+        return self
+
+    def build(self):
+        return HiveWarehouseSession(self._spark_session, self._jhwbuilder.build())
+
+
+class HiveWarehouseSession(object):
+    """This only can be created via HiveWarehouseBuilder.session(...).build()."""
+
+    def __init__(self, spark_session, jhwsession):
+        self._spark_session = spark_session
+        self._jhwsession = jhwsession
+
+    def executeQuery(self, sql):
+        assert isinstance(sql, basestring), "sql should be a string"
+
+        return DataFrame(self._jhwsession.executeQuery(sql), self._spark_session._wrapped)
+
+    def q(self, sql):
+        assert isinstance(sql, basestring), "sql should be a string"
+
+        return DataFrame(self._jhwsession.q(sql), self._spark_session._wrapped)
+
+    def execute(self, sql):
+        assert isinstance(sql, basestring), "sql should be a string"
+
+        return DataFrame(self._jhwsession.execute(sql), self._spark_session._wrapped)
+
+    def table(self, sql):
+        assert isinstance(sql, basestring), "sql should be a string"
+
+        return DataFrame(self._jhwsession.table(sql), self._spark_session._wrapped)
+
+    def session(self):
+        return self._spark_session
+
+    def setDatabase(self, name):
+        assert isinstance(name, basestring), "name should be a string"
+
+        self._jhwsession.setDatabase(name)
+
+    def showDatabases(self):
+        return DataFrame(self._jhwsession.showDatabases(), self._spark_session._wrapped)
+
+    def showTables(self):
+        return DataFrame(self._jhwsession.showTables(), self._spark_session._wrapped)
+
+    def describeTable(self, table):
+        assert isinstance(table, basestring), "table should be a string"
+
+        return DataFrame(self._jhwsession.describeTable(table), self._spark_session._wrapped)
+
+    def createDatabase(self, database, ifNotExists):
+        assert isinstance(ifNotExists, bool), "ifNotExists should be a bool"
+        assert isinstance(database, basestring), "database should be a string"
+
+        self._jhwsession.createDatabase(database, ifNotExists)
+
+    def createTable(self, tableName):
+        assert isinstance(tableName, basestring), "table should be a string"
+
+        return CreateTableBuilder(self._spark_session, self._jhwsession.createTable(tableName))
+
+    def dropDatabase(self, database, ifExists, cascade):
+        assert isinstance(database, basestring), "database should be a string"
+        assert isinstance(ifExists, bool), "ifExists should be a bool"
+        assert isinstance(cascade, bool), "cascade should be a bool"
+
+        self._jhwsession.dropDatabase(database, ifExists, cascade)
+
+    def dropTable(self, table, ifExists, purge):
+        assert isinstance(table, basestring), "table should be a string"
+        assert isinstance(ifExists, bool), "ifExists should be a bool"
+        assert isinstance(purge, bool), "purge should be a bool"
+
+        self._jhwsession.dropTable(table, ifExists, purge)
+
+
+class CreateTableBuilder(object):
+    """This only can be created via HiveWarehouseBuilder.session(...).build().createTable(...)."""
+
+    def __init__(self, spark_session, jtablebuilder):
+        self._spark_session = spark_session
+        self._jtablebuilder = jtablebuilder
+
+    def ifNotExists(self):
+        self._jtablebuilder.ifNotExists()
+        return self
+
+    def column(self, name, type):
+        assert isinstance(name, basestring), "name should be a string"
+        assert isinstance(type, basestring), "type should be a string"
+
+        self._jtablebuilder.column(name, type)
+        return self
+
+    def partition(self, name, type):
+        assert isinstance(name, basestring), "name should be a string"
+        assert isinstance(type, basestring), "type should be a string"
+
+        self._jtablebuilder.partition(name, type)
+        return self
+
+    def prop(self, key, value):
+        assert isinstance(key, basestring), "key should be a string"
+        assert isinstance(value, basestring), "value should be a string"
+
+        self._jtablebuilder.prop(key, value)
+        return self
+
+    def clusterBy(self, numBuckets, *columns):
+        assert isinstance(numBuckets, int), "numBuckets should be a number"
+        assert isinstance(columns, (list, tuple)) and isinstance(columns[0], basestring), \
+            "columns should be a list of strings"
+
+        # Create an array of objects
+        str_class = self._spark_session._jvm.String
+        arr = SparkContext._gateway.new_array(str_class, len(columns))
+        for i in range(len(columns)):
+            arr[i] = columns[i]
+        self._jtablebuilder.clusterBy(numBuckets, arr)
+        return self
+
+    def create(self):
+        self._jtablebuilder.create()
+
+    def toString(self):
+        return str(self._jtablebuilder.toString())

--- a/python/pyspark_llap/sql/tests.py
+++ b/python/pyspark_llap/sql/tests.py
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import os
+import glob
+
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import SparkSession
+
+from pyspark_llap.sql import HiveWarehouseBuilder
+from pyspark_llap.sql.session import CreateTableBuilder, HiveWarehouseSession
+
+TEST_USER = "userX"
+TEST_PASSWORD = "passwordX"
+TEST_HS2_URL = "jdbc:hive2://nohost:10084"
+TEST_DBCP2_CONF = "defaultQueryTimeout=100"
+TEST_EXEC_RESULTS_MAX = 12345
+TEST_DEFAULT_DB = "default12345"
+
+root = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../../target"))
+
+basepath = glob.glob("%s/scala-*" % root)
+assert len(basepath) > 0, "Build Spark LLAP first. ./target/scala-* directory was not found."
+basepath = basepath[0]
+
+jarpath = glob.glob("%s/spark-llap-assembly-*" % basepath)
+assert len(jarpath) == 1, \
+    "Multiple assemply jars were detected in ./target/scala-* directory or not found %s. " \
+    "Please clean up and build again." % jarpath
+jarpath = jarpath[0]
+
+testjarpath = glob.glob("%s/spark-llap*tests.jar" % basepath)
+assert len(testjarpath) == 1, \
+    "Multiple test:package jars were detected in ./target/scala-* directory or not found %s. " \
+    "Please clean up and build again." % testjarpath
+testjarpath = testjarpath[0]
+
+
+class HiveWarehouseBuilderTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = SparkSession.builder \
+            .master("local[4]") \
+            .appName(cls.__name__) \
+            .config(
+                "spark.driver.extraClassPath",
+                "%s:%s" % (jarpath, testjarpath)) \
+            .config(
+                "spark.executor.extraClassPath",
+                "%s:%s" % (jarpath, testjarpath)) \
+            .getOrCreate()
+
+        try:
+            cls.spark._jvm.com.hortonworks.spark.sql.hive.llap.MockConnection()
+        except:
+            cls.tearDownClass()
+            raise Exception("PySpark LLAP tests are dependent on mock classes defined in test"
+                            "codes. These should be compiled together, for example, by "
+                            "'sbt test:package'.")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()
+
+    conf_pairs = {
+        "null.exec.results.max": TEST_EXEC_RESULTS_MAX,
+        "null.user.name": TEST_USER,
+        "null.password": TEST_PASSWORD,
+        "null.hs2.url": TEST_HS2_URL,
+        "null.default.db": TEST_DEFAULT_DB,
+        "null.dbcp2.conf": TEST_DBCP2_CONF,
+    }
+
+    def test_all_builder_config(self):
+        session = self.spark
+        jstate = HiveWarehouseBuilder \
+            .session(session) \
+            .userPassword(TEST_USER, TEST_PASSWORD) \
+            .hs2url(TEST_HS2_URL) \
+            .dbcp2Conf(TEST_DBCP2_CONF) \
+            .maxExecResults(TEST_EXEC_RESULTS_MAX) \
+            .defaultDB(TEST_DEFAULT_DB) \
+            ._jhwbuilder.sessionStateForTest()
+
+        hive = session._jvm.com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseSessionImpl(jstate)
+        self.assertEqual(dict(hive.sessionState().getProps()), HiveWarehouseBuilderTest.conf_pairs)
+
+    def test_all_config(self):
+        session = self.spark
+
+        for key, value in HiveWarehouseBuilderTest.conf_pairs.items():
+            session.conf.set(key, value)
+
+        for key in HiveWarehouseBuilderTest.conf_pairs.keys():
+            # conf().getOption(key).get(), is used in 'MockHiveWarehouseSessionImpl'.
+            self.assertEqual(
+                str(session._jsparkSession.conf().getOption(key).get()),
+                str(HiveWarehouseBuilderTest.conf_pairs[key]))
+
+
+class HiveWarehouseSessionHiveQlTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = SparkSession.builder \
+            .master("local[4]") \
+            .appName(cls.__name__) \
+            .config(
+                "spark.driver.extraClassPath",
+                "%s:%s" % (jarpath, testjarpath)) \
+            .config(
+                "spark.executor.extraClassPath",
+                "%s:%s" % (jarpath, testjarpath)) \
+            .getOrCreate()
+        try:
+            cls.spark._jvm.com.hortonworks.spark.sql.hive.llap.MockConnection()
+        except:
+            cls.tearDownClass()
+            raise Exception("PySpark LLAP tests are dependent on mock classes defined in test"
+                            "codes. These should be compiled together, for example, by "
+                            "'sbt test:package'.")
+
+        session = cls.spark
+        jstate = HiveWarehouseBuilder \
+            .session(session) \
+            .userPassword(TEST_USER, TEST_PASSWORD) \
+            .hs2url(TEST_HS2_URL) \
+            .dbcp2Conf(TEST_DBCP2_CONF) \
+            .maxExecResults(TEST_EXEC_RESULTS_MAX) \
+            .defaultDB(TEST_DEFAULT_DB) \
+            ._jhwbuilder.sessionStateForTest()
+
+        cls.hive = HiveWarehouseSession(
+            session,
+            session._jvm.com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseSessionImpl(jstate))
+        cls.mockExecuteResultSize = session._jvm.com.hortonworks.spark.sql.hive.llap \
+            .MockHiveWarehouseSessionImpl.testFixture().getData().size()
+        cls.RESULT_SIZE = session._jvm.com.hortonworks.spark.sql.hive.llap \
+            .MockHiveWarehouseDataReader.RESULT_SIZE
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()
+
+    def test_execute_query(self):
+        self.assertEqual(self.hive.executeQuery("SELECT * FROM t1").count(), self.RESULT_SIZE)
+
+    def test_set_database(self):
+        self.hive.setDatabase(TEST_DEFAULT_DB)
+
+    def test_describe_table(self):
+        self.assertEqual(self.hive.describeTable("testTable").count(), self.mockExecuteResultSize)
+
+    def test_create_database(self):
+        self.hive.createDatabase(TEST_DEFAULT_DB, False)
+        self.hive.createDatabase(TEST_DEFAULT_DB, True)
+
+    def test_show_table(self):
+        self.assertEqual(self.hive.showTables().count(), self.mockExecuteResultSize)
+
+    def test_create_table(self):
+        CreateTableBuilder(self.spark, self.hive.createTable("TestTable")._jtablebuilder) \
+            .ifNotExists() \
+            .column("id", "int") \
+            .column("val", "string") \
+            .partition("id", "int") \
+            .clusterBy(100, "val") \
+            .prop("key", "value") \
+            .create()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,4 +46,3 @@ setup(
     ],
     url='https://github.com/hortonworks-spark/spark-llap',
 )
-

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+setup(
+    name='pyspark_llap',
+    version='1.2',
+    description='Apache Spark connector for Apache Hive LLAP',
+    author='Hyukjin Kwon',
+    author_email='hkwon@hortonworks.com',
+    license='http://www.apache.org/licenses/LICENSE-2.0',
+    packages=[
+        'pyspark_llap',
+        'pyspark_llap.sql',
+    ],
+    long_description=open('../README.md').read(),
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+    url='https://github.com/hortonworks-spark/spark-llap',
+)
+

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/DriverResultSet.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/DriverResultSet.java
@@ -39,4 +39,9 @@ public class DriverResultSet {
     public Dataset<Row> asDataFrame(SparkSession session) {
       return session.createDataFrame(data, schema);
     }
+
+    // Exposed for Python side.
+    public List<Row> getData() {
+        return this.data;
+    }
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
@@ -41,11 +41,18 @@ enum HWConf {
   }
 
   String getString(HiveWarehouseSessionState state) {
-    return Optional.
-      ofNullable((String) state.props.get(qualifiedKey)).
-      orElse(state.session.sparkContext().getConf().get(
-        qualifiedKey, (String) defaultValue)
-      );
+      String value = (String) state.props.get(qualifiedKey);
+      if (value == null) {
+          // There seems no way to call spark.conf.get(key, default)?
+          if (state.session.conf().getOption(qualifiedKey).nonEmpty()) {
+              return state.session.conf().getOption(qualifiedKey).get();
+          } else {
+              // Search it from the context too just in case.
+              return state.session.sparkContext().getConf().get(qualifiedKey, (String) defaultValue);
+          }
+      } else {
+          return value;
+      }
   }
 
   Long getLong(HiveWarehouseSessionState state) {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
@@ -64,8 +64,8 @@ public class HiveWarehouseBuilder {
         return new HiveWarehouseSessionImpl(this.sessionState);
     }
 
-    //Revealed internally for test only (not public)
-    HiveWarehouseSessionState sessionStateForTest() {
+    // Revealed internally for test only. Exposed for Python side.
+    public HiveWarehouseSessionState sessionStateForTest() {
         return this.sessionState;
     }
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionImpl.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionImpl.java
@@ -99,6 +99,11 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
     return sessionState.session;
   }
 
+  // Exposed for Python side.
+  public HiveWarehouseSessionState sessionState() {
+    return sessionState;
+  }
+
   SparkConf conf() {
     return sessionState.session.sparkContext().getConf();
   }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionState.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionState.java
@@ -22,7 +22,9 @@ import org.apache.spark.sql.SparkSession;
 import java.util.HashMap;
 import java.util.Map;
 
-class HiveWarehouseSessionState {
+// Exposed for Python side.
+public class HiveWarehouseSessionState {
+
     SparkSession session;
     Map<String, Object> props = new HashMap<>();
 
@@ -32,5 +34,10 @@ class HiveWarehouseSessionState {
 
     Long getLong(HWConf confValue) {
         return confValue.getLong(this);
+    }
+
+    // Exposed for Python side.
+    public Map<String, Object> getProps() {
+        return this.props;
     }
 }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -72,7 +72,7 @@ class HiveWarehouseSessionHiveQlTest {
 
     @Test
     void testDescribeTable() {
-       assertEquals(hive.describeTable("testTable").count(),
+        assertEquals(hive.describeTable("testTable").count(),
                mockExecuteResultSize);
     }
 

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockConnection.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockConnection.java
@@ -36,8 +36,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
-//Methods are empty on purpose
-class MockConnection implements Connection {
+// Methods are empty on purpose
+// Exposed for Python side.
+public class MockConnection implements Connection {
     @Override
     public Statement createStatement() throws SQLException {
         return null;

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseDataReader.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseDataReader.java
@@ -25,7 +25,8 @@ import java.io.IOException;
 
 public class MockHiveWarehouseDataReader implements DataReader<Row> {
 
-    static final int RESULT_SIZE = 10;
+    // Exposed for Python side.
+    public static final int RESULT_SIZE = 10;
     private int i = 0;
 
     @Override

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -42,6 +42,7 @@ class TestJavaProxy extends FunSuite {
 
     withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateDatabase)
     withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateTable)
+    withSetUpAndTearDown(hiveWarehouseSessionTest.testDescribeTable)
     withSetUpAndTearDown(hiveWarehouseSessionTest.testExecuteQuery)
     withSetUpAndTearDown(hiveWarehouseSessionTest.testSetDatabase)
     withSetUpAndTearDown(hiveWarehouseSessionTest.testShowTable)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the testing environment to Travis and the Python version of HiveWarehouseSession.

## How was this patch tested?

Manually tested and unit tests were added. The tests are basically the conversion of `HiveWarehouseBuilderTest` and `HiveWarehouseSessionHiveQlTest` at Java side.

Travis setting and Python setting was added to enable Python tests.

Manually tested with Python 3 and PyPy too.

Closes #221