### PR TITLE
[SPARK-LLAP-227] Fixup configuration classes. 

### DIFF
--- a/python/pyspark_llap/sql/tests.py
+++ b/python/pyspark_llap/sql/tests.py
@@ -80,12 +80,12 @@ class HiveWarehouseBuilderTest(unittest.TestCase):
         cls.spark.stop()
 
     conf_pairs = {
-        "null.exec.results.max": TEST_EXEC_RESULTS_MAX,
-        "null.user.name": TEST_USER,
-        "null.password": TEST_PASSWORD,
-        "null.hs2.url": TEST_HS2_URL,
-        "null.default.db": TEST_DEFAULT_DB,
-        "null.dbcp2.conf": TEST_DBCP2_CONF,
+        u'spark.datasource.hive.warehouse.password': u'passwordX',
+        u'spark.datasource.hive.warehouse.dbcp2.conf': u'defaultQueryTimeout=100',
+        u'spark.datasource.hive.warehouse.default.db': u'default12345',
+        u'spark.datasource.hive.warehouse.user.name': u'userX',
+        u'spark.datasource.hive.warehouse.hs2.url': u'jdbc:hive2://nohost:10084',
+        u'spark.datasource.hive.warehouse.exec.results.max': u'12345',
     }
 
     def test_all_builder_config(self):

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
@@ -17,6 +17,7 @@
 
 package com.hortonworks.spark.sql.hive.llap;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
@@ -18,6 +18,7 @@
 package com.hortonworks.spark.sql.hive.llap;
 
 import org.apache.spark.sql.SparkSession;
+import scala.Tuple2;
 
 public class HiveWarehouseBuilder {
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
@@ -30,32 +30,50 @@ public class HiveWarehouseBuilder {
     public static HiveWarehouseBuilder session(SparkSession session) {
         HiveWarehouseBuilder builder = new HiveWarehouseBuilder();
         builder.sessionState.session = session;
+        //Copy all static configuration (e.g. spark-defaults.conf)
+        //with keys matching HWConf.CONF_PREFIX into
+        //the SparkSQL session conf for this session
+        //Otherwise these settings will not be available to
+        //v2 DataSourceReader or DataSourceWriter
+        //See: {@link org.apache.spark.sql.sources.v2.SessionConfigSupport}
+        session.conf().getAll().foreach(new scala.runtime.AbstractFunction1<scala.Tuple2<String, String>, Object>() {
+          public Object apply(Tuple2<String, String> keyValue) {
+            String key = keyValue._1;
+            String value = keyValue._2;
+            if(key.startsWith(HiveWarehouseSession.CONF_PREFIX)) {
+              session.sessionState().conf().setConfString(key, value);
+            }
+            return null;
+          }
+        });
         return builder;
     }
 
     public HiveWarehouseBuilder userPassword(String user, String password) {
-        this.sessionState.props.put(HWConf.USER.qualifiedKey, user);
-        this.sessionState.props.put(HWConf.PASSWORD.qualifiedKey, password);
+      HWConf.USER.setString(sessionState, user);
+      HWConf.PASSWORD.setString(sessionState, password);
         return this;
     }
 
     public HiveWarehouseBuilder hs2url(String hs2url) {
-        this.sessionState.props.put(HWConf.HS2_URL.qualifiedKey, hs2url);
+      HWConf.HS2_URL.setString(sessionState, hs2url);
         return this;
     }
 
-    public HiveWarehouseBuilder maxExecResults(long maxExecResults) {
-        this.sessionState.props.put(HWConf.MAX_EXEC_RESULTS.qualifiedKey, maxExecResults);
+    //Hive JDBC doesn't support java.sql.Statement.setLargeMaxResults(long)
+    //Need to use setMaxResults(int) instead
+    public HiveWarehouseBuilder maxExecResults(int maxExecResults) {
+      HWConf.MAX_EXEC_RESULTS.setInt(sessionState, maxExecResults);
         return this;
     }
 
     public HiveWarehouseBuilder dbcp2Conf(String dbcp2Conf) {
-        this.sessionState.props.put(HWConf.DBCP2_CONF.qualifiedKey, dbcp2Conf);
+      HWConf.DBCP2_CONF.setString(sessionState, dbcp2Conf);
         return this;
     }
 
     public HiveWarehouseBuilder defaultDB(String defaultDB) {
-        this.sessionState.props.put(HWConf.DEFAULT_DB.qualifiedKey, defaultDB);
+      HWConf.DEFAULT_DB.setString(sessionState, defaultDB);
         return this;
     }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSession.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSession.java
@@ -24,6 +24,9 @@ import org.apache.spark.sql.SparkSession;
 public interface HiveWarehouseSession {
 
     String HIVE_WAREHOUSE_CONNECTOR = "com.hortonworks.spark.sql.hive.llap.HiveWarehouseConnector";
+    String SPARK_DATASOURCES_PREFIX = "spark.datasource";
+    String HIVE_WAREHOUSE_POSTFIX = "hive.warehouse";
+    String CONF_PREFIX = SPARK_DATASOURCES_PREFIX + "." + HIVE_WAREHOUSE_POSTFIX;
 
     Dataset<Row> executeQuery(String sql);
     Dataset<Row> q(String sql);

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionImpl.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionImpl.java
@@ -47,7 +47,7 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
     this.sessionState = sessionState;
     getConnector = () -> DefaultJDBCWrapper.getConnector(sessionState);
     executeStmt = (conn, database, sql) ->
-      DefaultJDBCWrapper.executeStmt(conn, database, sql, MAX_EXEC_RESULTS.getLong(sessionState));
+      DefaultJDBCWrapper.executeStmt(conn, database, sql, MAX_EXEC_RESULTS.getInt(sessionState));
     executeUpdate = (conn, database, sql) ->
       DefaultJDBCWrapper.executeUpdate(conn, database, sql);
     sessionState.session.listenerManager().register(new LlapQueryExecutionListener());
@@ -59,7 +59,6 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
 
   public Dataset<Row> executeQuery(String sql) {
     DataFrameReader dfr = session().read().format(HIVE_WAREHOUSE_CONNECTOR_INTERNAL).option("query", sql);
-    addConfigOptions(dfr);
     return dfr.load();
   }
 
@@ -91,7 +90,6 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
 
   public Dataset<Row> table(String sql) {
     DataFrameReader dfr = session().read().format(HIVE_WAREHOUSE_CONNECTOR_INTERNAL).option("table", sql);
-    addConfigOptions(dfr);
     return dfr.load();
   }
 
@@ -110,8 +108,7 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
 
   /* Catalog helpers */
   public void setDatabase(String name) {
-    execute(useDatabase(name));
-    this.sessionState.props.put(DEFAULT_DB.qualifiedKey, name);
+    HWConf.DEFAULT_DB.setString(sessionState, name);
   }
 
   public Dataset<Row> showDatabases() {
@@ -132,8 +129,9 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
 
   public void dropTable(String table, boolean ifExists, boolean purge) {
     try (Connection conn = getConnector.get()) {
-      executeInternal(HiveQlUtil.useDatabase(DEFAULT_DB.getString(sessionState)), conn);
-      executeUpdateInternal(HiveQlUtil.dropTable(table, ifExists, purge), conn);
+      executeUpdateInternal(HiveQlUtil.useDatabase(DEFAULT_DB.getString(sessionState)), conn);
+      String dropTable = HiveQlUtil.dropTable(table, ifExists, purge);
+      executeUpdateInternal(dropTable, conn);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -147,13 +145,6 @@ public class HiveWarehouseSessionImpl implements HiveWarehouseSession {
     return new CreateTableBuilder(this, DEFAULT_DB.getString(sessionState), tableName);
   }
 
-  private void addConfigOptions(DataFrameReader dfr) {
-    dfr.option(USER.simpleKey, USER.getString(sessionState));
-    dfr.option(PASSWORD.simpleKey, PASSWORD.getString(sessionState));
-    dfr.option(HS2_URL.simpleKey, HS2_URL.getString(sessionState));
-    dfr.option(DBCP2_CONF.simpleKey, DBCP2_CONF.getString(sessionState));
-    dfr.option(DEFAULT_DB.simpleKey, DEFAULT_DB.getString(sessionState));
-  }
 
 }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionState.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionState.java
@@ -26,18 +26,11 @@ import java.util.Map;
 public class HiveWarehouseSessionState {
 
     SparkSession session;
-    Map<String, Object> props = new HashMap<>();
+    Map<String, String> props = new HashMap<>();
 
-    String getString(HWConf confValue) {
-       return confValue.getString(this);
-    }
-
-    Long getLong(HWConf confValue) {
-        return confValue.getLong(this);
-    }
 
     // Exposed for Python side.
-    public Map<String, Object> getProps() {
+    public Map<String, String> getProps() {
         return this.props;
     }
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/util/HiveQlUtil.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/util/HiveQlUtil.java
@@ -47,8 +47,8 @@ public class HiveQlUtil {
     //Requires jdbc Connection attached to current database (see HiveWarehouseSessionImpl.dropTable)
     public static String dropTable(String table, boolean ifExists, boolean purge) {
         return format("DROP TABLE %s %s %s",
-                table,
                 orBlank(ifExists, "IF EXISTS"),
+                table,
                 orBlank(purge, "PURGE"));
     }
 

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -162,7 +162,7 @@ class JDBCWrapper {
                  maxExecResults: Long): DriverResultSet = {
     useDatabase(conn, currentDatabase)
     val stmt = conn.prepareStatement(query)
-    stmt.setLargeMaxRows(maxExecResults)
+    stmt.setMaxRows(maxExecResults.asInstanceOf[Int])
     val rs = stmt.executeQuery()
     log.debug(query)
     try {
@@ -183,6 +183,7 @@ class JDBCWrapper {
       return new DriverResultSet(data, schema)
     } finally {
       rs.close()
+      stmt.close()
     }
   }
 
@@ -195,13 +196,16 @@ class JDBCWrapper {
     useDatabase(conn, currentDatabase)
     val stmt = conn.prepareStatement(query)
     val succeed = stmt.execute()
+    stmt.close()
     log.debug(query)
     succeed
   }
 
   def useDatabase(conn: Connection, currentDatabase: String) {
     if (currentDatabase != null) {
-      conn.prepareStatement(s"USE $currentDatabase").execute()
+      val stmt = conn.prepareStatement(s"USE $currentDatabase")
+      stmt.execute()
+      stmt.close()
     }
   }
 

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -30,7 +30,7 @@ class HiveWarehouseBuilderTest {
     static final String TEST_PASSWORD = "passwordX";
     static final String TEST_HS2_URL = "jdbc:hive2://nohost:10084";
     static final String TEST_DBCP2_CONF = "defaultQueryTimeout=100";
-    static final Long TEST_EXEC_RESULTS_MAX = Long.valueOf(12345L);
+    static final Integer TEST_EXEC_RESULTS_MAX = 12345;
     static final String TEST_DEFAULT_DB = "default12345";
 
     transient SparkSession session = null;
@@ -62,13 +62,13 @@ class HiveWarehouseBuilderTest {
                         .defaultDB(TEST_DEFAULT_DB)
                         .sessionStateForTest();
         MockHiveWarehouseSessionImpl hive = new MockHiveWarehouseSessionImpl(sessionState);
-        assertEquals(hive.sessionState.session, session);
-        assertEquals(HWConf.USER.getString(hive.sessionState), TEST_USER);
-        assertEquals(HWConf.PASSWORD.getString(hive.sessionState), TEST_PASSWORD);
-        assertEquals(HWConf.HS2_URL.getString(hive.sessionState), TEST_HS2_URL);
-        assertEquals(HWConf.DBCP2_CONF.getString(hive.sessionState), TEST_DBCP2_CONF);
-        assertEquals(HWConf.MAX_EXEC_RESULTS.getLong(hive.sessionState), TEST_EXEC_RESULTS_MAX);
-        assertEquals(HWConf.DEFAULT_DB.getString(hive.sessionState), TEST_DEFAULT_DB);
+        assertEquals(hive.session(), session);
+        assertEquals(HWConf.USER.getString(sessionState), TEST_USER);
+        assertEquals(HWConf.PASSWORD.getString(sessionState), TEST_PASSWORD);
+        assertEquals(HWConf.HS2_URL.getString(sessionState), TEST_HS2_URL);
+        assertEquals(HWConf.DBCP2_CONF.getString(sessionState), TEST_DBCP2_CONF);
+        assertEquals(HWConf.MAX_EXEC_RESULTS.getInt(sessionState), TEST_EXEC_RESULTS_MAX);
+        assertEquals(HWConf.DEFAULT_DB.getString(sessionState), TEST_DEFAULT_DB);
     }
 
     @Test
@@ -89,7 +89,7 @@ class HiveWarehouseBuilderTest {
         assertEquals(HWConf.PASSWORD.getString(hive.sessionState), TEST_PASSWORD);
         assertEquals(HWConf.HS2_URL.getString(hive.sessionState), TEST_HS2_URL);
         assertEquals(HWConf.DBCP2_CONF.getString(hive.sessionState), TEST_DBCP2_CONF);
-        assertEquals(HWConf.MAX_EXEC_RESULTS.getLong(hive.sessionState), TEST_EXEC_RESULTS_MAX);
+        assertEquals(HWConf.MAX_EXEC_RESULTS.getInt(hive.sessionState), TEST_EXEC_RESULTS_MAX);
         assertEquals(HWConf.DEFAULT_DB.getString(hive.sessionState), TEST_DEFAULT_DB);
     }
 }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
@@ -32,7 +32,7 @@ public class MockHiveWarehouseConnector implements DataSourceV2, ReadSupport, Se
 
     @Override
     public String keyPrefix() {
-        return HWConf.HIVE_WAREHOUSE_CONF_PREFIX;
+        return HiveWarehouseSession.CONF_PREFIX;
     }
 
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

Previous code had some loopholes where configuration wasn't available to DataSourceWriter. 
The DataSourceWriter code hasn't been merged yet, so this PR is in preparation for that.

Also added a fix for the arguments to HiveQl.dropDatabase in this PR.

## How was this patch tested?

Modified existing UT.
