### PR TITLE
[SPARK-LLAP-229] Add LLAP ReadSupport

### DIFF
--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
@@ -32,7 +32,7 @@ public class HiveWarehouseBuilder {
         HiveWarehouseBuilder builder = new HiveWarehouseBuilder();
         builder.sessionState.session = session;
         //Copy all static configuration (e.g. spark-defaults.conf)
-        //with keys matching HWConf.CONF_PREFIX into
+        //with keys matching HiveWarehouseSession.CONF_PREFIX into
         //the SparkSQL session conf for this session
         //Otherwise these settings will not be available to
         //v2 DataSourceReader or DataSourceWriter

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
@@ -1,0 +1,46 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.sources.v2.DataSourceV2;
+import org.apache.spark.sql.sources.v2.ReadSupport;
+import org.apache.spark.sql.sources.v2.SessionConfigSupport;
+import org.apache.spark.sql.sources.v2.WriteSupport;
+import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, SessionConfigSupport {
+
+  private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseConnector.class);
+
+  @Override public DataSourceReader createReader(DataSourceOptions options) {
+    try {
+      Map<String, String> params = getOptions(options);
+      return new HiveWarehouseDataSourceReader(params);
+    } catch (IOException e) {
+      LOG.error("Error creating {}", getClass().getName());
+      LOG.error(ExceptionUtils.getStackTrace(e));
+    }
+    return null;
+  }
+
+  @Override public String keyPrefix() {
+    return com.hortonworks.spark.sql.hive.llap.HiveWarehouseSession.HIVE_WAREHOUSE_POSTFIX;
+  }
+
+  private static Map<String, String> getOptions(DataSourceOptions options) {
+    return options.asMap();
+  }
+
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
@@ -20,6 +20,14 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
+/*
+ * Driver:
+ *   UserCode -> HiveWarehouseConnector -> HiveWarehouseDataSourceReader -> HiveWarehouseDataReaderFactory
+ * Task serializer:
+ *   HiveWarehouseDataReaderFactory (Driver) -> bytes -> HiveWarehouseDataReaderFactory (Executor task)
+ * Executor:
+ *   HiveWarehouseDataReaderFactory -> HiveWarehouseDataReader
+ */
 public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, SessionConfigSupport {
 
   private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseConnector.class);
@@ -31,12 +39,12 @@ public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, Sessio
     } catch (IOException e) {
       LOG.error("Error creating {}", getClass().getName());
       LOG.error(ExceptionUtils.getStackTrace(e));
+      throw new RuntimeException(e);
     }
-    return null;
   }
 
   @Override public String keyPrefix() {
-    return com.hortonworks.spark.sql.hive.llap.HiveWarehouseSession.HIVE_WAREHOUSE_POSTFIX;
+    return HiveWarehouseSession.HIVE_WAREHOUSE_POSTFIX;
   }
 
   private static Map<String, String> getOptions(DataSourceOptions options) {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
@@ -1,0 +1,57 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.arrow.vector.FieldVector;
+import org.apache.hadoop.hive.llap.LlapArrowBatchRecordReader;
+import org.apache.hadoop.hive.llap.LlapBaseInputFormat;
+import org.apache.hadoop.hive.llap.LlapInputSplit;
+import org.apache.hadoop.hive.ql.io.arrow.ArrowWrapperWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.vectorized.ArrowColumnVector;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class HiveWarehouseDataReader implements DataReader<ColumnarBatch> {
+
+    private LlapArrowBatchRecordReader reader;
+    private ArrowWrapperWritable wrapperWritable = new ArrowWrapperWritable();
+
+    public HiveWarehouseDataReader(LlapInputSplit split, JobConf conf) throws Exception {
+        LlapBaseInputFormat input = new LlapBaseInputFormat(true, Long.MAX_VALUE);
+        this.reader = (LlapArrowBatchRecordReader) input.getRecordReader(split, conf, null);
+    }
+
+    @Override
+    public boolean next() throws IOException {
+        boolean hasNextBatch = reader.next(null, wrapperWritable);
+        return hasNextBatch;
+    }
+
+    @Override
+    public ColumnarBatch get() {
+            List<FieldVector> fieldVectors = wrapperWritable.getVectorSchemaRoot().getFieldVectors();
+            ColumnVector[] columnVectors = new ColumnVector[fieldVectors.size()];
+            Iterator<FieldVector> iterator = fieldVectors.iterator();
+            int rowCount = -1;
+            for(int i = 0; i < columnVectors.length; i++) {
+                FieldVector fieldVector = iterator.next();
+                columnVectors[i] = new ArrowColumnVector(fieldVector);
+                if(rowCount == -1) {
+                    rowCount = fieldVector.getValueCount();
+                }
+            }
+            ColumnarBatch columnarBatch = new ColumnarBatch(columnVectors);
+            columnarBatch.setNumRows(rowCount);
+            return columnarBatch;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.reader.close();
+    }
+
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
@@ -17,41 +17,43 @@ import java.util.List;
 
 public class HiveWarehouseDataReader implements DataReader<ColumnarBatch> {
 
-    private LlapArrowBatchRecordReader reader;
-    private ArrowWrapperWritable wrapperWritable = new ArrowWrapperWritable();
+  private LlapArrowBatchRecordReader reader;
+  private ArrowWrapperWritable wrapperWritable = new ArrowWrapperWritable();
+  private long arrowAllocatorMax;
 
-    public HiveWarehouseDataReader(LlapInputSplit split, JobConf conf) throws Exception {
-        LlapBaseInputFormat input = new LlapBaseInputFormat(true, Long.MAX_VALUE);
-        this.reader = (LlapArrowBatchRecordReader) input.getRecordReader(split, conf, null);
-    }
+  public HiveWarehouseDataReader(LlapInputSplit split, JobConf conf, long arrowAllocatorMax) throws Exception {
+    LlapBaseInputFormat input = new LlapBaseInputFormat(true, arrowAllocatorMax);
+    this.reader = (LlapArrowBatchRecordReader) input.getRecordReader(split, conf, null);
+  }
 
-    @Override
-    public boolean next() throws IOException {
-        boolean hasNextBatch = reader.next(null, wrapperWritable);
-        return hasNextBatch;
-    }
+  @Override public boolean next() throws IOException {
+    boolean hasNextBatch = reader.next(null, wrapperWritable);
+    return hasNextBatch;
+  }
 
-    @Override
-    public ColumnarBatch get() {
-            List<FieldVector> fieldVectors = wrapperWritable.getVectorSchemaRoot().getFieldVectors();
-            ColumnVector[] columnVectors = new ColumnVector[fieldVectors.size()];
-            Iterator<FieldVector> iterator = fieldVectors.iterator();
-            int rowCount = -1;
-            for(int i = 0; i < columnVectors.length; i++) {
-                FieldVector fieldVector = iterator.next();
-                columnVectors[i] = new ArrowColumnVector(fieldVector);
-                if(rowCount == -1) {
-                    rowCount = fieldVector.getValueCount();
-                }
-            }
-            ColumnarBatch columnarBatch = new ColumnarBatch(columnVectors);
-            columnarBatch.setNumRows(rowCount);
-            return columnarBatch;
+  @Override public ColumnarBatch get() {
+    //Spark asks you to convert one column at a time so that different
+    //column types can be handled differently.
+    //NumOfCols << NumOfRows so this is negligible
+    List<FieldVector> fieldVectors = wrapperWritable.getVectorSchemaRoot().getFieldVectors();
+    ColumnVector[] columnVectors = new ColumnVector[fieldVectors.size()];
+    Iterator<FieldVector> iterator = fieldVectors.iterator();
+    int rowCount = -1;
+    for (int i = 0; i < columnVectors.length; i++) {
+      FieldVector fieldVector = iterator.next();
+      columnVectors[i] = new ArrowColumnVector(fieldVector);
+      if (rowCount == -1) {
+        //All column vectors have same length so we can get rowCount from any column
+        rowCount = fieldVector.getValueCount();
+      }
     }
+    ColumnarBatch columnarBatch = new ColumnarBatch(columnVectors);
+    columnarBatch.setNumRows(rowCount);
+    return columnarBatch;
+  }
 
-    @Override
-    public void close() throws IOException {
-        this.reader.close();
-    }
+  @Override public void close() throws IOException {
+    this.reader.close();
+  }
 
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
@@ -16,13 +16,15 @@ public class HiveWarehouseDataReaderFactory implements DataReaderFactory<Columna
     private byte[] splitBytes;
     private byte[] confBytes;
     private transient InputSplit split;
+    private long arrowAllocatorMax;
 
     //No-arg constructor for executors
     public HiveWarehouseDataReaderFactory() {}
 
     //Driver-side setup
-    public HiveWarehouseDataReaderFactory(InputSplit split, JobConf conf) {
+    public HiveWarehouseDataReaderFactory(InputSplit split, JobConf conf, long arrowAllocatorMax) {
         this.split = split;
+        this.arrowAllocatorMax = arrowAllocatorMax;
         try {
             //Serialize split and conf for executors
             //TODO optimize/compress
@@ -64,7 +66,7 @@ public class HiveWarehouseDataReaderFactory implements DataReaderFactory<Columna
             conf.readFields(dis2);
             dis.close();
             dis2.close();
-            return new HiveWarehouseDataReader(llapInputSplit, conf);
+            return new HiveWarehouseDataReader(llapInputSplit, conf, arrowAllocatorMax);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
@@ -1,0 +1,72 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.hive.llap.LlapInputSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+public class HiveWarehouseDataReaderFactory implements DataReaderFactory<ColumnarBatch> {
+    private byte[] splitBytes;
+    private byte[] confBytes;
+    private transient InputSplit split;
+
+    //No-arg constructor for executors
+    public HiveWarehouseDataReaderFactory() {}
+
+    //Driver-side setup
+    public HiveWarehouseDataReaderFactory(InputSplit split, JobConf conf) {
+        this.split = split;
+        try {
+            //Serialize split and conf for executors
+            //TODO optimize/compress
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream dos = new DataOutputStream(baos);
+            split.write(dos);
+            dos.close();
+            splitBytes = baos.toByteArray();
+            baos.reset();
+            DataOutputStream dos2 = new DataOutputStream(baos);
+            conf.write(dos2);
+            dos2.close();
+            confBytes = baos.toByteArray();
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String[] preferredLocations() {
+        try {
+            return this.split.getLocations();
+        } catch(Exception e) {
+            //preferredLocations specifies to return empty array if no preference
+            return new String[0];
+        }
+    }
+
+    @Override
+    public DataReader<ColumnarBatch> createDataReader() {
+        LlapInputSplit llapInputSplit = new LlapInputSplit();
+        ByteArrayInputStream bais = new ByteArrayInputStream(splitBytes);
+        DataInputStream dis = new DataInputStream(bais);
+        JobConf conf = new JobConf();
+        ByteArrayInputStream bais2 = new ByteArrayInputStream(confBytes);
+        DataInputStream dis2 = new DataInputStream(bais2);
+        try {
+            llapInputSplit.readFields(dis);
+            conf.readFields(dis2);
+            dis.close();
+            dis2.close();
+            return new HiveWarehouseDataReader(llapInputSplit, conf);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceReader.java
@@ -32,175 +32,182 @@ import static scala.collection.JavaConversions.asScalaBuffer;
 
 public class HiveWarehouseDataSourceReader
     implements DataSourceReader, SupportsPushDownRequiredColumns, SupportsScanColumnarBatch, SupportsPushDownFilters {
-    StructType schema = null;
-    Filter[] pushedFilters = new Filter[0];
-    Map<String, String> options;
-    private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseDataSourceReader.class);
 
-    public HiveWarehouseDataSourceReader(Map<String, String> options) throws IOException {
-        this.options = options;
+  StructType schema = null;
+  Filter[] pushedFilters = new Filter[0];
+  Map<String, String> options;
+  private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseDataSourceReader.class);
+
+  public HiveWarehouseDataSourceReader(Map<String, String> options) throws IOException {
+    this.options = options;
+  }
+
+  String getQueryString(String[] requiredColumns, Filter[] filters) throws Exception {
+    String selectCols = "count(*)";
+    if (requiredColumns.length > 0) {
+      selectCols = String.join(",", requiredColumns);
+    }
+    String baseQuery = null;
+    if (getQueryType().equals("table")) {
+      baseQuery = "select * from " + options.get("table");
+    } else {
+      baseQuery = options.get("query");
     }
 
-    String getQueryString(String[] requiredColumns, Filter[] filters) throws Exception {
-        String selectCols = "count(*)";
-        if (requiredColumns.length > 0) {
-            selectCols = String.join(",", requiredColumns);
-        }
-        String baseQuery = null;
-        if(getQueryType().equals("table")) {
-            baseQuery = "select * from " + options.get("table");
-        } else {
-            baseQuery = options.get("query");
-        }
+    String baseQueryAlias = "q_" + UUID.randomUUID().toString().replaceAll("[^A-Za-z0-9 ]", "");
+    Seq<Filter> filterSeq = asScalaBuffer(Arrays.asList(filters)).seq();
+    String whereClause = buildWhereClause(schema, filterSeq);
 
-        String baseQueryAlias = "q_" + UUID.randomUUID().toString().replaceAll("[^A-Za-z0-9 ]", "");
-        Seq<Filter> filterSeq = asScalaBuffer(Arrays.asList(filters)).seq();
-        String whereClause = buildWhereClause(schema, filterSeq);
+    String format = "select %s from (%s) as %s %s";
+    String queryString = format(format, selectCols, baseQuery, baseQueryAlias, whereClause);
 
-        String format = "select %s from (%s) as %s %s";
-        String queryString = format(format, selectCols, baseQuery, baseQueryAlias, whereClause);
+    return queryString;
+  }
 
-        return queryString;
+  private StatementType getQueryType() throws Exception {
+    return StatementType.fromOptions(options);
+  }
+
+  private static class TableRef {
+    private String databaseName;
+    private String tableName;
+
+    TableRef(String databaseName, String tableName) {
+      this.databaseName = databaseName;
+      this.tableName = tableName;
     }
+  }
 
-    private StatementType getQueryType() throws Exception {
-        return StatementType.fromOptions(options);
+  private TableRef getDbTableNames(String nameStr) {
+    String[] nameParts = nameStr.split("\\.");
+    if (nameParts.length != 2) {
+      throw new IllegalArgumentException("Expected " + nameStr + " to be in the form db.table");
     }
+    return new TableRef(nameParts[0], nameParts[1]);
+  }
 
-    private static class TableRef {
-        private String databaseName;
-        private String tableName;
-        TableRef(String databaseName, String tableName) {
-            this.databaseName = databaseName;
-            this.tableName = tableName;
-        }
+  private StructType getTableSchema() throws Exception {
+    String url = HWConf.HS2_URL.getFromOptionsMap(options);
+    String user = HWConf.USER.getFromOptionsMap(options);
+    String dbcp2Configs = HWConf.DBCP2_CONF.getFromOptionsMap(options);
+    Connection conn = DefaultJDBCWrapper.getConnector(Option.empty(), url, user, dbcp2Configs);
+    StatementType queryKey = getQueryType();
+
+    try {
+      if (queryKey == StatementType.FULL_TABLE_SCAN) {
+        TableRef tableRef = getDbTableNames(options.get("table"));
+        return DefaultJDBCWrapper.resolveTable(conn, tableRef.databaseName, tableRef.tableName);
+      } else {
+        System.out.println(options.toString());
+        String currentDatabase = HWConf.DEFAULT_DB.getFromOptionsMap(options);
+        return DefaultJDBCWrapper.resolveQuery(conn, currentDatabase, options.get("query"));
+      }
+    } finally {
+      conn.close();
     }
+  }
 
-    private TableRef getDbTableNames(String nameStr) {
-        String[] nameParts = nameStr.split("\\.");
-        if (nameParts.length != 2) {
-            throw new IllegalArgumentException("Expected " + nameStr + " to be in the form db.table");
-        }
-        return new TableRef(nameParts[0], nameParts[1]);
+  @Override public StructType readSchema() {
+    try {
+      if (schema == null) {
+        schema = getTableSchema();
+      }
+      return schema;
+    } catch (Exception e) {
+      LOG.error("Unable to read table schema");
+      throw new RuntimeException(e);
     }
+  }
 
-    private StructType getTableSchema() throws Exception {
-        String url = HWConf.HS2_URL.getFromOptionsMap(options);
-        String user = HWConf.USER.getFromOptionsMap(options);
-        String dbcp2Configs = HWConf.DBCP2_CONF.getFromOptionsMap(options);
-        Connection conn = DefaultJDBCWrapper.getConnector(Option.empty(), url, user, dbcp2Configs);
-	      StatementType queryKey = getQueryType();
+  @Override public Filter[] pushFilters(Filter[] filters) {
+    pushedFilters = filters;
+    return new Filter[0];
+  }
 
+  @Override public Filter[] pushedFilters() {
+    return pushedFilters;
+  }
+
+  @Override public void pruneColumns(StructType requiredSchema) {
+    this.schema = requiredSchema;
+  }
+
+  private String[] requiredColumns(StructType schema) {
+    String[] requiredColumns = new String[schema.length()];
+    int i = 0;
+    for (StructField field : schema.fields()) {
+      requiredColumns[i] = field.name();
+      i++;
+    }
+    return requiredColumns;
+  }
+
+  static JobConf createJobConf(Map<String, String> options, String queryString) {
+    JobConf jobConf = new JobConf(SparkContext.getOrCreate().hadoopConfiguration());
+    jobConf.set("hive.llap.zk.registry.user", "hive");
+    jobConf.set("llap.if.hs2.connection", HWConf.HS2_URL.getFromOptionsMap(options));
+    if (queryString != null) {
+      jobConf.set("llap.if.query", queryString);
+    }
+    jobConf.set("llap.if.user", HWConf.USER.getFromOptionsMap(options));
+    jobConf.set("llap.if.pwd", HWConf.PASSWORD.getFromOptionsMap(options));
+    if (options.containsKey("default.db")) {
+      jobConf.set("llap.if.database", HWConf.DEFAULT_DB.getFromOptionsMap(options));
+    }
+    if (!options.containsKey("handleid")) {
+      String handleId = UUID.randomUUID().toString();
+      options.put("handleid", handleId);
+    }
+    jobConf.set("llap.if.handleid", options.get("handleid"));
+    return jobConf;
+  }
+
+  @Override public List<DataReaderFactory<ColumnarBatch>> createBatchDataReaderFactories() {
+    try {
+      boolean countStar = this.schema.length() == 0;
+      String queryString = getQueryString(requiredColumns(schema), pushedFilters);
+      InputSplit[] splits = null;
+      JobConf jobConf = createJobConf(options, queryString);
+      if (countStar) {
+        //TODO: Add back countStar workaround in subsequent PR
+        throw new UnsupportedOperationException();
+      } else {
+        LlapBaseInputFormat llapInputFormat = new LlapBaseInputFormat(false, Long.MAX_VALUE);
         try {
-            if (queryKey == StatementType.FULL_TABLE_SCAN) {
-                TableRef tableRef = getDbTableNames(options.get("table"));
-                return DefaultJDBCWrapper.resolveTable(conn, tableRef.databaseName, tableRef.tableName);
-            } else {
-		System.out.println(options.toString());
-                String currentDatabase = HWConf.DEFAULT_DB.getFromOptionsMap(options);
-                return DefaultJDBCWrapper.resolveQuery(conn, currentDatabase, options.get("query"));
-            }
-        } finally {
-            conn.close();
+          //TODO apparently numSplits doesn't do anything
+          splits = llapInputFormat.getSplits(jobConf, 1);
+        } catch (IOException e) {
+          LOG.error("Unable to submit query to HS2");
+          throw new RuntimeException(e);
         }
+      }
+      List<DataReaderFactory<ColumnarBatch>> factories = new ArrayList<>();
+      for (InputSplit split : splits) {
+        factories.add(new HiveWarehouseDataReaderFactory(split, jobConf, getArrowAllocatorMax()));
+      }
+      return factories;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @Override
-    public StructType readSchema() {
-        try {
-            if (schema == null) {
-              schema = getTableSchema();
-            }
-            return schema;
-        } catch(Exception e) {
-            LOG.error("Unable to read table schema");
-            throw new RuntimeException(e);
-        }
+  private long getArrowAllocatorMax () {
+    String arrowAllocatorMaxString = HWConf.ARROW_ALLOCATOR_MAX.getFromOptionsMap(options);
+    long arrowAllocatorMax = (Long) HWConf.ARROW_ALLOCATOR_MAX.defaultValue;
+    if (arrowAllocatorMaxString != null) {
+      arrowAllocatorMax = Long.parseLong(arrowAllocatorMaxString);
     }
+    LOG.debug("Ceiling for Arrow direct buffers {}", arrowAllocatorMax);
+    return arrowAllocatorMax;
+  }
 
-    @Override
-    public Filter[] pushFilters(Filter[] filters) {
-        pushedFilters = filters;
-        return new Filter[0];
+  public void close() {
+    LOG.info("Closing resources for handleid: {}", options.get("handleid"));
+    try {
+      LlapBaseInputFormat.close(options.get("handleid"));
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
     }
-
-    @Override
-    public Filter[] pushedFilters() {
-        return pushedFilters;
-    }
-
-    @Override
-    public void pruneColumns(StructType requiredSchema) {
-        this.schema = requiredSchema;
-    }
-
-    private String[] requiredColumns(StructType schema) {
-        String[] requiredColumns = new String[schema.length()];
-        int i = 0;
-        for(StructField field : schema.fields()) {
-            requiredColumns[i] = field.name();
-            i++;
-        }
-        return requiredColumns;
-    }
-
-    static JobConf createJobConf(Map<String, String> options, String queryString) {
-        JobConf jobConf = new JobConf(SparkContext.getOrCreate().hadoopConfiguration());
-        jobConf.set("hive.llap.zk.registry.user", "hive");
-        jobConf.set("llap.if.hs2.connection", HWConf.HS2_URL.getFromOptionsMap(options));
-        if(queryString != null) {
-            jobConf.set("llap.if.query", queryString);
-        }
-        jobConf.set("llap.if.user", HWConf.USER.getFromOptionsMap(options));
-        jobConf.set("llap.if.pwd", HWConf.PASSWORD.getFromOptionsMap(options));
-        if (options.containsKey("default.db")) {
-            jobConf.set("llap.if.database", HWConf.DEFAULT_DB.getFromOptionsMap(options));
-        }
-        if (!options.containsKey("handleid")) {
-	        String handleId = UUID.randomUUID().toString();
-          options.put("handleid", handleId);
-        } 
-        jobConf.set("llap.if.handleid", options.get("handleid"));
-        return jobConf;
-    }
-
-    @Override
-    public List<DataReaderFactory<ColumnarBatch>> createBatchDataReaderFactories() {
-        try {
-            boolean countStar = this.schema.length() == 0;
-            String queryString = getQueryString(requiredColumns(schema), pushedFilters);
-            InputSplit[] splits = null;
-            JobConf jobConf = createJobConf(options, queryString);
-            if (countStar) {
-              //TODO: Add back countStar workaround in subsequent PR
-              throw new UnsupportedOperationException();
-            } else {
-                LlapBaseInputFormat llapInputFormat = new LlapBaseInputFormat(false, Long.MAX_VALUE);
-                try {
-                    //TODO apparently numSplits doesn't do anything
-                    splits = llapInputFormat.getSplits(jobConf, 1);
-                } catch (IOException e) {
-                    LOG.error("Unable to submit query to HS2");
-                    throw new RuntimeException(e);
-                }
-            }
-            List<DataReaderFactory<ColumnarBatch>> factories = new ArrayList<>();
-            for (InputSplit split : splits) {
-                factories.add(new HiveWarehouseDataReaderFactory(split, jobConf));
-            }
-            return factories;
-        } catch(Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void close() {
-        LOG.info("Closing resources for handleid: {}", options.get("handleid"));
-        try {
-	        LlapBaseInputFormat.close(options.get("handleid"));
-	      } catch(IOException ioe) {
-		      throw new RuntimeException(ioe);
-	      }
-    }
+  }
 
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceReader.java
@@ -1,0 +1,206 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.hive.llap.LlapBaseInputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
+import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownFilters;
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.sources.v2.reader.SupportsScanColumnarBatch;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.collection.Seq;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.hortonworks.spark.sql.hive.llap.FilterPushdown.buildWhereClause;
+import static java.lang.String.format;
+import static scala.collection.JavaConversions.asScalaBuffer;
+
+public class HiveWarehouseDataSourceReader
+    implements DataSourceReader, SupportsPushDownRequiredColumns, SupportsScanColumnarBatch, SupportsPushDownFilters {
+    StructType schema = null;
+    Filter[] pushedFilters = new Filter[0];
+    Map<String, String> options;
+    private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseDataSourceReader.class);
+
+    public HiveWarehouseDataSourceReader(Map<String, String> options) throws IOException {
+        this.options = options;
+    }
+
+    String getQueryString(String[] requiredColumns, Filter[] filters) throws Exception {
+        String selectCols = "count(*)";
+        if (requiredColumns.length > 0) {
+            selectCols = String.join(",", requiredColumns);
+        }
+        String baseQuery = null;
+        if(getQueryType().equals("table")) {
+            baseQuery = "select * from " + options.get("table");
+        } else {
+            baseQuery = options.get("query");
+        }
+
+        String baseQueryAlias = "q_" + UUID.randomUUID().toString().replaceAll("[^A-Za-z0-9 ]", "");
+        Seq<Filter> filterSeq = asScalaBuffer(Arrays.asList(filters)).seq();
+        String whereClause = buildWhereClause(schema, filterSeq);
+
+        String format = "select %s from (%s) as %s %s";
+        String queryString = format(format, selectCols, baseQuery, baseQueryAlias, whereClause);
+
+        return queryString;
+    }
+
+    private StatementType getQueryType() throws Exception {
+        return StatementType.fromOptions(options);
+    }
+
+    private static class TableRef {
+        private String databaseName;
+        private String tableName;
+        TableRef(String databaseName, String tableName) {
+            this.databaseName = databaseName;
+            this.tableName = tableName;
+        }
+    }
+
+    private TableRef getDbTableNames(String nameStr) {
+        String[] nameParts = nameStr.split("\\.");
+        if (nameParts.length != 2) {
+            throw new IllegalArgumentException("Expected " + nameStr + " to be in the form db.table");
+        }
+        return new TableRef(nameParts[0], nameParts[1]);
+    }
+
+    private StructType getTableSchema() throws Exception {
+        String url = HWConf.HS2_URL.getFromOptionsMap(options);
+        String user = HWConf.USER.getFromOptionsMap(options);
+        String dbcp2Configs = HWConf.DBCP2_CONF.getFromOptionsMap(options);
+        Connection conn = DefaultJDBCWrapper.getConnector(Option.empty(), url, user, dbcp2Configs);
+	      StatementType queryKey = getQueryType();
+
+        try {
+            if (queryKey == StatementType.FULL_TABLE_SCAN) {
+                TableRef tableRef = getDbTableNames(options.get("table"));
+                return DefaultJDBCWrapper.resolveTable(conn, tableRef.databaseName, tableRef.tableName);
+            } else {
+		System.out.println(options.toString());
+                String currentDatabase = HWConf.DEFAULT_DB.getFromOptionsMap(options);
+                return DefaultJDBCWrapper.resolveQuery(conn, currentDatabase, options.get("query"));
+            }
+        } finally {
+            conn.close();
+        }
+    }
+
+    @Override
+    public StructType readSchema() {
+        try {
+            if (schema == null) {
+              schema = getTableSchema();
+            }
+            return schema;
+        } catch(Exception e) {
+            LOG.error("Unable to read table schema");
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Filter[] pushFilters(Filter[] filters) {
+        pushedFilters = filters;
+        return new Filter[0];
+    }
+
+    @Override
+    public Filter[] pushedFilters() {
+        return pushedFilters;
+    }
+
+    @Override
+    public void pruneColumns(StructType requiredSchema) {
+        this.schema = requiredSchema;
+    }
+
+    private String[] requiredColumns(StructType schema) {
+        String[] requiredColumns = new String[schema.length()];
+        int i = 0;
+        for(StructField field : schema.fields()) {
+            requiredColumns[i] = field.name();
+            i++;
+        }
+        return requiredColumns;
+    }
+
+    static JobConf createJobConf(Map<String, String> options, String queryString) {
+        JobConf jobConf = new JobConf(SparkContext.getOrCreate().hadoopConfiguration());
+        jobConf.set("hive.llap.zk.registry.user", "hive");
+        jobConf.set("llap.if.hs2.connection", HWConf.HS2_URL.getFromOptionsMap(options));
+        if(queryString != null) {
+            jobConf.set("llap.if.query", queryString);
+        }
+        jobConf.set("llap.if.user", HWConf.USER.getFromOptionsMap(options));
+        jobConf.set("llap.if.pwd", HWConf.PASSWORD.getFromOptionsMap(options));
+        if (options.containsKey("default.db")) {
+            jobConf.set("llap.if.database", HWConf.DEFAULT_DB.getFromOptionsMap(options));
+        }
+        if (!options.containsKey("handleid")) {
+	        String handleId = UUID.randomUUID().toString();
+          options.put("handleid", handleId);
+        } 
+        jobConf.set("llap.if.handleid", options.get("handleid"));
+        return jobConf;
+    }
+
+    @Override
+    public List<DataReaderFactory<ColumnarBatch>> createBatchDataReaderFactories() {
+        try {
+            boolean countStar = this.schema.length() == 0;
+            String queryString = getQueryString(requiredColumns(schema), pushedFilters);
+            InputSplit[] splits = null;
+            JobConf jobConf = createJobConf(options, queryString);
+            if (countStar) {
+              //TODO: Add back countStar workaround in subsequent PR
+              throw new UnsupportedOperationException();
+            } else {
+                LlapBaseInputFormat llapInputFormat = new LlapBaseInputFormat(false, Long.MAX_VALUE);
+                try {
+                    //TODO apparently numSplits doesn't do anything
+                    splits = llapInputFormat.getSplits(jobConf, 1);
+                } catch (IOException e) {
+                    LOG.error("Unable to submit query to HS2");
+                    throw new RuntimeException(e);
+                }
+            }
+            List<DataReaderFactory<ColumnarBatch>> factories = new ArrayList<>();
+            for (InputSplit split : splits) {
+                factories.add(new HiveWarehouseDataReaderFactory(split, jobConf));
+            }
+            return factories;
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close() {
+        LOG.info("Closing resources for handleid: {}", options.get("handleid"));
+        try {
+	        LlapBaseInputFormat.close(options.get("handleid"));
+	      } catch(IOException ioe) {
+		      throw new RuntimeException(ioe);
+	      }
+    }
+
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/StatementType.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/StatementType.java
@@ -1,0 +1,30 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import java.util.Map;
+
+public enum StatementType {
+    GENERIC,
+    SELECT_QUERY,
+    FULL_TABLE_SCAN;
+
+    public static StatementType fromOptions(Map<String, String> options) {
+        int optionCount = 0;
+        StatementType type = null;
+        if(options.containsKey("stmt")) {
+            type = GENERIC;
+            optionCount++;
+        }
+        if(options.containsKey("query")) {
+            type = SELECT_QUERY;
+            optionCount++;
+        }
+        if(options.containsKey("table")) {
+            type = FULL_TABLE_SCAN;
+            optionCount++;
+        }
+        if(optionCount != 1) {
+            throw new IllegalArgumentException("Use one and only one of: stmt, query, table");
+        }
+        return type;
+    }
+}

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/LlapQueryExecutionListener.scala
@@ -20,6 +20,7 @@ package com.hortonworks.spark.sql.hive.llap
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.util.QueryExecutionListener
+import org.apache.spark.sql.execution.datasources.v2._
 
 class LlapQueryExecutionListener extends QueryExecutionListener with Logging {
 
@@ -31,6 +32,9 @@ class LlapQueryExecutionListener extends QueryExecutionListener with Logging {
       case r: RowDataSourceScanExec if r.relation.isInstanceOf[LlapRelation] =>
         r.relation.asInstanceOf[LlapRelation].close()
         logDebug(s"Closing Hive connection via ${classOf[LlapRelation].getName}")
+      case s: DataSourceV2ScanExec if s.reader.isInstanceOf[HiveWarehouseDataSourceReader] =>
+        s.reader.asInstanceOf[HiveWarehouseDataSourceReader].close()
+        logDebug(s"Closing Hive connection via ${classOf[HiveWarehouseDataSourceReader].getName}")
       case _ =>
     }
   }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Refactor SQL logic from LlapRelation for DataSourceV2
Change from HadoopRDD/LlapInputFormat to ArrowStreamReader based input.
Add SupportsScanColumnarBatch.

## How was this patch tested?

Ran end-to-end smoke tests with 7 LLAP daemons/7 Spark-Yarn executors and TPC-DS 10TB. Tested queries with 600 splits/tasks.

Formal system-tests are in development.
