### PR TITLE
[SPARK-LLAP-232] Add a simple test for `HiveWarehouseBuilder.session(session).build()`

### DIFF
--- a/python/pyspark_llap/sql/tests.py
+++ b/python/pyspark_llap/sql/tests.py
@@ -114,6 +114,10 @@ class HiveWarehouseBuilderTest(unittest.TestCase):
                 str(session._jsparkSession.conf().getOption(key).get()),
                 str(HiveWarehouseBuilderTest.conf_pairs[key]))
 
+    def test_session_build(self):
+        session = self.spark
+        self.assertTrue(HiveWarehouseBuilder.session(session).build() is not None)
+
 
 class HiveWarehouseSessionHiveQlTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
coverage report --include "*pyspark_llap-*pyspark_llap/*" --show-missing
Name                                                                                                                        Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------------------------------------------------------------------------
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/__init__.py           0      0   100%
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/sql/__init__.py       2      0   100%
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/sql/session.py      118     20    83%   21-22, 78, 94-96, 99-101, 104-106, 109, 117, 139-143, 146-150, 202
---------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL           
```

```
coverage report --include "*pyspark_llap-*pyspark_llap/*" --show-missing
Name                                                                                                                       Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------------------------------------
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/__init__.py           0      0   100%
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/sql/__init__.py       2      0   100%
/.../pyspark_llap-1.2-2.3-3.0-SNAPSHOT.zip/pyspark_llap/sql/session.py      118     19    84%   21-22, 94-96, 99-101, 104-106, 109, 117, 139-143, 146-150, 202
--------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL
```

Not a big deal but it tests the lline 78L

## How was this patch tested?

N/A