### PR TITLE
SPARK-LLAP-235: Add kerberos support for HS2 url. Refactor SparkSession setup/tearDown into test base class

### DIFF
--- a/python/pyspark_llap/sql/session.py
+++ b/python/pyspark_llap/sql/session.py
@@ -74,6 +74,16 @@ class HiveWarehouseBuilder(object):
         self._jhwbuilder.defaultDB(defaultDB)
         return self
 
+    def principal(self, principal):
+        assert isinstance(defaultDB, basestring), "principal should be a string"
+
+        self._jhwbuilder.principal(principal)
+        return self
+
+    def credentialsEnabled(self):
+        self._jhwbuilder.credentialsEnabled()
+        return self
+
     def build(self):
         return HiveWarehouseSession(self._spark_session, self._jhwbuilder.build())
 

--- a/python/pyspark_llap/sql/tests.py
+++ b/python/pyspark_llap/sql/tests.py
@@ -84,7 +84,6 @@ class HiveWarehouseBuilderTest(unittest.TestCase):
         u'spark.datasource.hive.warehouse.dbcp2.conf': u'defaultQueryTimeout=100',
         u'spark.datasource.hive.warehouse.default.db': u'default12345',
         u'spark.datasource.hive.warehouse.user.name': u'userX',
-        u'spark.datasource.hive.warehouse.hs2.url': u'jdbc:hive2://nohost:10084',
         u'spark.datasource.hive.warehouse.exec.results.max': u'12345',
     }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
@@ -19,16 +19,21 @@ package com.hortonworks.spark.sql.hive.llap;
 
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.spark.sql.SparkSession;
+
+import static java.lang.String.format;
 
 /**
  * See: {@link org.apache.spark.sql.sources.v2.SessionConfigSupport}
  */
-enum HWConf {
+public enum HWConf {
 
   //ENUM(shortKey, qualifiedKey, default)
   USER("user.name", warehouseKey("user.name"), ""),
   PASSWORD("password", warehouseKey("password"), ""),
-  HS2_URL("hs2.url", warehouseKey("hs2.url"), "jdbc:hive2://localhost:10500"),
+  RESOLVED_HS2_URL("hs2.url.resolved", warehouseKey("hs2.url.resolved"), ""),
   DBCP2_CONF("dbcp2.conf", warehouseKey("dbcp2.conf"), null),
   DEFAULT_DB("default.db", warehouseKey("default.db"), "default"),
   MAX_EXEC_RESULTS("exec.results.max", warehouseKey("exec.results.max"), 1000),
@@ -45,6 +50,11 @@ enum HWConf {
     return HiveWarehouseSession.CONF_PREFIX + "." + keySuffix;
   }
 
+  private static Logger LOG = LoggerFactory.getLogger(HWConf.class);
+  static final String HIVESERVER2_CREDENTIAL_ENABLED = "spark.security.credentials.hiveserver2.enabled";
+  static final String HIVESERVER2_JDBC_URL_PRINCIPAL = "spark.sql.hive.hiveserver2.jdbc.url.principal";
+  static final String HIVESERVER2_JDBC_URL = "spark.sql.hive.hiveserver2.jdbc.url";
+
   void setString(HiveWarehouseSessionState state, String value) {
     state.props.put(qualifiedKey, value);
     state.session.sessionState().conf().setConfString(qualifiedKey, value);
@@ -56,8 +66,8 @@ enum HWConf {
   }
 
   //This is called from executors so it can't depend explicitly on session state
-  String getFromOptionsMap(Map<String, String> options) {
-    return Optional.ofNullable(options.get(simpleKey)).orElse((String) defaultValue);
+  public String getFromOptionsMap(Map<String, String> options) {
+    return Optional.ofNullable(options.get(simpleKey)).orElse(defaultValue == null ? null : defaultValue.toString());
   }
 
   String getString(HiveWarehouseSessionState state) {
@@ -81,4 +91,45 @@ enum HWConf {
   String simpleKey;
   String qualifiedKey;
   Object defaultValue;
+  /**
+   * Return connection URL (with replaced proxy user name if exists).
+   */
+  public static String getConnectionUrl(HiveWarehouseSessionState state) {
+    String userString = USER.getString(state);
+    if (userString == null) {
+      userString = "";
+}
+    String urlString = getConnectionUrlFromConf(state);
+    String returnValue = urlString.replace("${user}", userString);
+    LOG.warn("Using HS2 URL: {}", returnValue);
+    return returnValue;
+  }
+
+  /**
+   * For the given HiveServer2 JDBC URLs, attach the postfix strings if needed.
+   *
+   * For kerberized clusters,
+   *
+   * 1. YARN cluster mode: ";auth=delegationToken"
+   * 2. YARN client mode: ";principal=hive/_HOST@EXAMPLE.COM"
+   *
+   * Non-kerberied clusters,
+   * 3. Use the given URLs.
+   */
+   public static String getConnectionUrlFromConf(HiveWarehouseSessionState state) {
+     SparkSession sparkSession = state.session;
+     if (sparkSession.conf().get(HIVESERVER2_CREDENTIAL_ENABLED, "false").equals("true")) {
+       // 1. YARN Cluster mode for kerberized clusters
+       return format("%s;auth=delegationToken", sparkSession.conf().get(HIVESERVER2_JDBC_URL));
+     } else if (sparkSession.conf().contains(HIVESERVER2_JDBC_URL_PRINCIPAL)) {
+       // 2. YARN Client mode for kerberized clusters
+       return format("%s;principal=%s",
+           sparkSession.conf().get(HIVESERVER2_JDBC_URL),
+           sparkSession.conf().get(HIVESERVER2_JDBC_URL_PRINCIPAL));
+     } else {
+       // 3. For non-kerberized cluster
+       return sparkSession.conf().get(HIVESERVER2_JDBC_URL);
+     }
+   }
+
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilder.java
@@ -20,6 +20,10 @@ package com.hortonworks.spark.sql.hive.llap;
 import org.apache.spark.sql.SparkSession;
 import scala.Tuple2;
 
+import static com.hortonworks.spark.sql.hive.llap.HWConf.HIVESERVER2_CREDENTIAL_ENABLED;
+import static com.hortonworks.spark.sql.hive.llap.HWConf.HIVESERVER2_JDBC_URL;
+import static com.hortonworks.spark.sql.hive.llap.HWConf.HIVESERVER2_JDBC_URL_PRINCIPAL;
+
 public class HiveWarehouseBuilder {
 
     HiveWarehouseSessionState sessionState = new HiveWarehouseSessionState();
@@ -57,7 +61,17 @@ public class HiveWarehouseBuilder {
     }
 
     public HiveWarehouseBuilder hs2url(String hs2url) {
-      HWConf.HS2_URL.setString(sessionState, hs2url);
+      sessionState.session.conf().set(HIVESERVER2_JDBC_URL, hs2url);
+      return this;
+    }
+
+    public HiveWarehouseBuilder principal(String principal) {
+      sessionState.session.conf().set(HIVESERVER2_JDBC_URL_PRINCIPAL, principal);
+      return this;
+    }
+
+    public HiveWarehouseBuilder credentialsEnabled() {
+      sessionState.session.conf().set(HIVESERVER2_CREDENTIAL_ENABLED, "true");
         return this;
     }
 
@@ -80,6 +94,7 @@ public class HiveWarehouseBuilder {
 
     //This is the only way for application to obtain a HiveWarehouseSessionImpl
     public HiveWarehouseSessionImpl build() {
+      HWConf.RESOLVED_HS2_URL.setString(sessionState, HWConf.getConnectionUrl(sessionState));
         return new HiveWarehouseSessionImpl(this.sessionState);
     }
 

--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/HS2JDBCWrapper.scala
@@ -275,7 +275,7 @@ class JDBCWrapper {
   def getConnector(sessionState: HiveWarehouseSessionState): Connection = {
     return getConnector(
       Option.empty,
-      HWConf.HS2_URL.getString(sessionState),
+      HWConf.RESOLVED_HS2_URL.getString(sessionState),
       HWConf.USER.getString(sessionState),
       HWConf.DBCP2_CONF.getString(sessionState)
     )

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseBuilderTest.java
@@ -24,31 +24,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-class HiveWarehouseBuilderTest {
+class HiveWarehouseBuilderTest extends SessionTestBase {
 
     static final String TEST_USER = "userX";
     static final String TEST_PASSWORD = "passwordX";
-    static final String TEST_HS2_URL = "jdbc:hive2://nohost:10084";
     static final String TEST_DBCP2_CONF = "defaultQueryTimeout=100";
     static final Integer TEST_EXEC_RESULTS_MAX = 12345;
     static final String TEST_DEFAULT_DB = "default12345";
 
-    transient SparkSession session = null;
-
-    @Before
-    public void setUp() {
-        session = SparkSession
-                .builder()
-                .master("local")
-                .appName("HiveWarehouseConnector test")
-                .getOrCreate();
-    }
-
-    @After
-    public void tearDown() {
-        session.stop();
-        session = null;
-    }
 
     @Test
     void testAllBuilderConfig() {
@@ -56,7 +39,6 @@ class HiveWarehouseBuilderTest {
                 HiveWarehouseBuilder
                         .session(session)
                         .userPassword(TEST_USER, TEST_PASSWORD)
-                        .hs2url(TEST_HS2_URL)
                         .dbcp2Conf(TEST_DBCP2_CONF)
                         .maxExecResults(TEST_EXEC_RESULTS_MAX)
                         .defaultDB(TEST_DEFAULT_DB)
@@ -65,7 +47,6 @@ class HiveWarehouseBuilderTest {
         assertEquals(hive.session(), session);
         assertEquals(HWConf.USER.getString(sessionState), TEST_USER);
         assertEquals(HWConf.PASSWORD.getString(sessionState), TEST_PASSWORD);
-        assertEquals(HWConf.HS2_URL.getString(sessionState), TEST_HS2_URL);
         assertEquals(HWConf.DBCP2_CONF.getString(sessionState), TEST_DBCP2_CONF);
         assertEquals(HWConf.MAX_EXEC_RESULTS.getInt(sessionState), TEST_EXEC_RESULTS_MAX);
         assertEquals(HWConf.DEFAULT_DB.getString(sessionState), TEST_DEFAULT_DB);
@@ -75,7 +56,6 @@ class HiveWarehouseBuilderTest {
     void testAllConfConfig() {
         session.conf().set(HWConf.USER.qualifiedKey, TEST_USER);
         session.conf().set(HWConf.PASSWORD.qualifiedKey, TEST_PASSWORD);
-        session.conf().set(HWConf.HS2_URL.qualifiedKey, TEST_HS2_URL);
         session.conf().set(HWConf.DBCP2_CONF.qualifiedKey, TEST_DBCP2_CONF);
         session.conf().set(HWConf.MAX_EXEC_RESULTS.qualifiedKey, TEST_EXEC_RESULTS_MAX);
         session.conf().set(HWConf.DEFAULT_DB.qualifiedKey, TEST_DEFAULT_DB);
@@ -87,7 +67,6 @@ class HiveWarehouseBuilderTest {
         assertEquals(hive.sessionState.session, session);
         assertEquals(HWConf.USER.getString(hive.sessionState), TEST_USER);
         assertEquals(HWConf.PASSWORD.getString(hive.sessionState), TEST_PASSWORD);
-        assertEquals(HWConf.HS2_URL.getString(hive.sessionState), TEST_HS2_URL);
         assertEquals(HWConf.DBCP2_CONF.getString(hive.sessionState), TEST_DBCP2_CONF);
         assertEquals(HWConf.MAX_EXEC_RESULTS.getInt(hive.sessionState), TEST_EXEC_RESULTS_MAX);
         assertEquals(HWConf.DEFAULT_DB.getString(hive.sessionState), TEST_DEFAULT_DB);

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseSessionHiveQlTest.java
@@ -23,22 +23,18 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.hortonworks.spark.sql.hive.llap.HiveWarehouseBuilderTest.*;
+import static com.hortonworks.spark.sql.hive.llap.TestSecureHS2Url.TEST_HS2_URL;
 import static org.junit.Assert.assertEquals;
 
-class HiveWarehouseSessionHiveQlTest {
+class HiveWarehouseSessionHiveQlTest extends SessionTestBase {
 
     private HiveWarehouseSession hive;
     private int mockExecuteResultSize;
 
-    transient SparkSession session = null;
 
     @Before
-    void setUp() {
-        session = SparkSession
-                .builder()
-                .master("local")
-                .appName("HiveWarehouseSessionHiveQlTest test")
-                .getOrCreate();
+    public void setUp() {
+        super.setUp();
         HiveWarehouseSessionState sessionState =
                 HiveWarehouseBuilder
                         .session(session)
@@ -53,11 +49,6 @@ class HiveWarehouseSessionHiveQlTest {
                  MockHiveWarehouseSessionImpl.testFixture().data.size();
     }
 
-    @After
-    public void tearDown() {
-        session.stop();
-        session = null;
-    }
 
     @Test
     void testExecuteQuery() {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/SessionTestBase.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/SessionTestBase.java
@@ -1,0 +1,30 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.SparkSession;
+import org.junit.After;
+import org.junit.Before;
+
+public class SessionTestBase {
+  transient SparkSession session = null;
+  String name;
+
+  public SessionTestBase() {
+    this.name = getClass().getSimpleName();
+  }
+
+  @Before
+  public void setUp() {
+    session = SparkSession
+        .builder()
+        .master("local")
+        .appName(name)
+        .getOrCreate();
+  }
+
+  @After
+  public void tearDown() {
+    session.stop();
+    session = null;
+  }
+
+}

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/TestSecureHS2Url.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/TestSecureHS2Url.java
@@ -1,0 +1,58 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.SparkSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class TestSecureHS2Url extends SessionTestBase {
+
+  static final String TEST_HS2_URL = "jdbc:hive2://example.com:10084";
+  static final String TEST_PRINCIPAL = "testUser/_HOST@EXAMPLE.com";
+
+  static final String KERBERIZED_CLUSTER_MODE_URL = TEST_HS2_URL + ";auth=delegationToken";
+  static final String KERBERIZED_CLIENT_MODE_URL =
+      TEST_HS2_URL +
+          ";principal=" +
+          TEST_PRINCIPAL;
+
+  @Test
+  public void kerberizedClusterMode() {
+    HiveWarehouseSessionState state = HiveWarehouseBuilder
+        .session(session)
+        .hs2url(TEST_HS2_URL)
+        .credentialsEnabled()
+        .build()
+        .sessionState;
+
+    String resolvedUrl = HWConf.RESOLVED_HS2_URL.getString(state);
+    assertEquals(resolvedUrl, KERBERIZED_CLUSTER_MODE_URL);
+  }
+
+  @Test
+  public void kerberizedClientMode() {
+    HiveWarehouseSessionState state = HiveWarehouseBuilder
+        .session(session)
+        .hs2url(TEST_HS2_URL)
+        .principal(TEST_PRINCIPAL)
+        .build()
+        .sessionState;
+
+    String resolvedUrl = HWConf.RESOLVED_HS2_URL.getString(state);
+    assertEquals(resolvedUrl, KERBERIZED_CLIENT_MODE_URL);
+  }
+
+  @Test
+  public void nonKerberized() {
+    HiveWarehouseSessionState state = HiveWarehouseBuilder
+        .session(session)
+        .hs2url(TEST_HS2_URL)
+        .build()
+        .sessionState;
+
+    String resolvedUrl = HWConf.RESOLVED_HS2_URL.getString(state);
+    assertEquals(resolvedUrl, TEST_HS2_URL);
+  }
+
+}

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -20,31 +20,35 @@ package com.hortonworks.spark.sql.hive.llap
 import org.scalatest.FunSuite
 
 class TestJavaProxy extends FunSuite {
-  test("HiveWarehouseBuilder") {
-    val builderTest = new HiveWarehouseBuilderTest()
-    try {
-      builderTest.setUp()
-      builderTest.testAllBuilderConfig()
-    } finally {
-      builderTest.tearDown()
-    }
-  }
 
-  test("HiveWarehouseSession") {
-    val hiveWarehouseSessionTest = new HiveWarehouseSessionHiveQlTest()
-
-    def withSetUpAndTearDown(test: () => Unit): Unit = try {
-      hiveWarehouseSessionTest.setUp()
+  def withSetUpAndTearDown(suite: SessionTestBase, test: () => Unit): Unit = try {
+    suite.setUp()
       test()
     } finally {
-      hiveWarehouseSessionTest.tearDown()
+    suite.tearDown()
     }
 
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateDatabase)
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testCreateTable)
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testDescribeTable)
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testExecuteQuery)
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testSetDatabase)
-    withSetUpAndTearDown(hiveWarehouseSessionTest.testShowTable)
+  test("HiveWarehouseBuilderTest") {
+    val test = new HiveWarehouseBuilderTest()
+    withSetUpAndTearDown(test, test.testAllBuilderConfig)
+    withSetUpAndTearDown(test, test.testAllConfConfig)
   }
+
+  test("HiveWarehouseSessionHiveQlTest") {
+    val test = new HiveWarehouseSessionHiveQlTest()
+    withSetUpAndTearDown(test, test.testCreateDatabase)
+    withSetUpAndTearDown(test, test.testCreateTable)
+    withSetUpAndTearDown(test, test.testDescribeTable)
+    withSetUpAndTearDown(test, test.testExecuteQuery)
+    withSetUpAndTearDown(test, test.testSetDatabase)
+    withSetUpAndTearDown(test, test.testShowTable)
+  }
+
+  test("TestSecureHS2Url") {
+    val test = new TestSecureHS2Url()
+    withSetUpAndTearDown(test, test.kerberizedClusterMode)
+    withSetUpAndTearDown(test, test.kerberizedClientMode)
+    withSetUpAndTearDown(test, test.nonKerberized)
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolve HS2URL using: `spark.security.credentials.hiveserver2.enabled`, `spark.sql.hive.hiveserver2.jdbc.url.principal`, and `spark.sql.hive.hiveserver2.jdbc.url`

Add "principal" and "credentialsEnabled" helper to HiveWarehouseBuilder

Refactored some test code

## How was this patch tested?

Added UT.
Manually smoke tested the 3 security modes on kerberized and non-kerberized cluster.
Manually smoke tested kerberized authentication to Ranger is working.
