### PR TITLE
Add batch WriteSupport

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -220,9 +220,7 @@ assemblyMergeStrategy in assembly := {
   case PathList("org","apache","logging","log4j","core","config","plugins","Log4j2Plugins.dat") => MergeStrategy.first
   case PathList("META-INF", "services", "org.apache.hadoop.fs.FileSystem") => MergeStrategy.discard
   case x if x.endsWith("package-info.class") => MergeStrategy.first
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
+  case x => MergeStrategy.first
 }
 
 def pyFilesZipRecursive(source: File, destZipFile: File): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -220,7 +220,9 @@ assemblyMergeStrategy in assembly := {
   case PathList("org","apache","logging","log4j","core","config","plugins","Log4j2Plugins.dat") => MergeStrategy.first
   case PathList("META-INF", "services", "org.apache.hadoop.fs.FileSystem") => MergeStrategy.discard
   case x if x.endsWith("package-info.class") => MergeStrategy.first
-  case x => MergeStrategy.first
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
 }
 
 def pyFilesZipRecursive(source: File, destZipFile: File): Unit = {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseConnector.java
@@ -1,16 +1,24 @@
 package com.hortonworks.spark.sql.hive.llap;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.DataSourceV2;
 import org.apache.spark.sql.sources.v2.ReadSupport;
+import org.apache.spark.sql.sources.v2.WriteSupport;
 import org.apache.spark.sql.sources.v2.SessionConfigSupport;
 import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
+import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 /*
  * Driver:
@@ -20,7 +28,7 @@ import java.util.Map;
  * Executor:
  *   HiveWarehouseDataReaderFactory -> HiveWarehouseDataReader
  */
-public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, SessionConfigSupport {
+public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, SessionConfigSupport, WriteSupport {
 
   private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseConnector.class);
 
@@ -34,6 +42,16 @@ public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, Sessio
     }
   }
 
+  @Override
+  public Optional<DataSourceWriter> createWriter(String jobId, StructType schema,
+      SaveMode mode, DataSourceOptions options) {
+    Map<String, String> params = getOptions(options);
+    String stagingDirPrefix = HWConf.LOAD_STAGING_DIR.getFromOptionsMap(params);
+    Path path = new Path(stagingDirPrefix);
+    Configuration conf = SparkSession.getActiveSession().get().sparkContext().hadoopConfiguration();
+    return Optional.of(getDataSourceWriter(jobId, schema, path, params, conf));
+  }
+
   @Override public String keyPrefix() {
     return HiveWarehouseSession.HIVE_WAREHOUSE_POSTFIX;
   }
@@ -45,6 +63,11 @@ public class HiveWarehouseConnector implements DataSourceV2, ReadSupport, Sessio
 
   protected DataSourceReader getDataSourceReader(Map<String, String> params) throws IOException {
     return new HiveWarehouseDataSourceReader(params);
+  }
+
+  protected DataSourceWriter getDataSourceWriter(String jobId, StructType schema,
+      Path path, Map<String, String> options, Configuration conf) {
+    return new HiveWarehouseDataSourceWriter(options, jobId, schema, path, conf);
   }
 
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
@@ -1,0 +1,74 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
+import org.apache.spark.sql.sources.v2.writer.SupportsWriteInternalRow;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+
+import java.sql.Connection;
+import java.util.Map;
+
+import static com.hortonworks.spark.sql.hive.llap.util.HiveQlUtil.loadInto;
+import static java.lang.String.format;
+
+public class HiveWarehouseDataSourceWriter implements SupportsWriteInternalRow {
+  protected String jobId;
+  protected StructType schema;
+  protected Path path;
+  protected Configuration conf;
+  protected Map<String, String> options;
+  private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseDataSourceWriter.class);
+
+  public HiveWarehouseDataSourceWriter(Map<String, String> options, String jobId, StructType schema,
+      Path path, Configuration conf) {
+    this.options = options;
+    this.jobId = jobId;
+    this.schema = schema;
+    this.path = new Path(path, jobId);
+    this.conf = conf;
+  }
+
+  @Override public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
+    return new HiveWarehouseDataWriterFactory(jobId, schema, path, new SerializableConfiguration(conf));
+  }
+
+  @Override public void commit(WriterCommitMessage[] messages) {
+    try {
+      String url = HWConf.RESOLVED_HS2_URL.getFromOptionsMap(options);
+      String user = HWConf.USER.getFromOptionsMap(options);
+      String dbcp2Configs = HWConf.DBCP2_CONF.getFromOptionsMap(options);
+      String database = HWConf.DEFAULT_DB.getFromOptionsMap(options);
+      String table = options.get("table");
+      try (Connection conn = DefaultJDBCWrapper.getConnector(Option.empty(), url, user, dbcp2Configs)) {
+        DefaultJDBCWrapper.executeUpdate(conn, database, loadInto(this.path.toString(), database, table));
+      } catch (java.sql.SQLException e) {
+        throw new RuntimeException(e);
+      }
+    } finally {
+      try {
+        path.getFileSystem(conf).delete(path, true);
+      } catch(Exception e) {
+        LOG.warn("Failed to cleanup temp dir {}", path.toString());
+      }
+      LOG.info("Commit job {}", jobId);
+    }
+  }
+
+  @Override public void abort(WriterCommitMessage[] messages) {
+    try {
+      path.getFileSystem(conf).delete(path, true);
+    } catch(Exception e) {
+      LOG.warn("Failed to cleanup temp dir {}", path.toString());
+    }
+    LOG.error("Aborted DataWriter job {}", jobId);
+  }
+
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
@@ -37,7 +37,7 @@ public class HiveWarehouseDataSourceWriter implements SupportsWriteInternalRow {
   }
 
   @Override public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
-    return new HiveWarehouseDataWriterFactory(jobId, schema, path, new SerializableConfiguration(conf));
+    return new HiveWarehouseDataWriterFactory(jobId, schema, path.toString(), new SerializableConfiguration(conf));
   }
 
   @Override public void commit(WriterCommitMessage[] messages) {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
@@ -4,10 +4,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.TaskAttemptContext;
-import org.apache.hadoop.mapred.TaskAttemptContextImpl;
-import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.OutputWriter;
@@ -39,9 +38,8 @@ public class HiveWarehouseDataWriter implements DataWriter<InternalRow> {
     this.attemptNumber = attemptNumber;
     this.fs = fs;
     this.filePath = filePath;
-    JobConf jobConf = new JobConf(conf);
-    jobConf.set("orc.mapred.output.schema", this.schema.simpleString());
-    TaskAttemptContext tac = new TaskAttemptContextImpl(jobConf, new TaskAttemptID());
+    conf.set("orc.mapred.output.schema", this.schema.simpleString());
+    TaskAttemptContext tac = new TaskAttemptContextImpl(conf, new TaskAttemptID());
     this.out = getOutputWriter(filePath.toString(), schema, tac);
   }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
@@ -1,0 +1,69 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapred.TaskAttemptContextImpl;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.OutputWriter;
+import org.apache.spark.sql.execution.datasources.orc.OrcOutputWriter;
+import org.apache.spark.sql.sources.v2.writer.DataWriter;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class HiveWarehouseDataWriter implements DataWriter<InternalRow> {
+  private static Logger LOG = LoggerFactory.getLogger(HiveWarehouseDataWriter.class);
+
+  private String jobId;
+  private StructType schema;
+  private int partitionId;
+  private int attemptNumber;
+  private FileSystem fs;
+  private Path filePath;
+  private OutputWriter out;
+
+  public HiveWarehouseDataWriter(Configuration conf, String jobId, StructType schema,
+      int partitionId, int attemptNumber, FileSystem fs, Path filePath) {
+    this.jobId = jobId;
+    this.schema = schema;
+    this.partitionId = partitionId;
+    this.attemptNumber = attemptNumber;
+    this.fs = fs;
+    this.filePath = filePath;
+    JobConf jobConf = new JobConf(conf);
+    jobConf.set("orc.mapred.output.schema", this.schema.simpleString());
+    TaskAttemptContext tac = new TaskAttemptContextImpl(jobConf, new TaskAttemptID());
+    this.out = getOutputWriter(filePath.toString(), schema, tac);
+  }
+
+  @Override public void write(InternalRow record) throws IOException {
+    out.write(record);
+  }
+
+  @Override public WriterCommitMessage commit() throws IOException {
+    out.close();
+    return new SimpleWriterCommitMessage(String.format("COMMIT %s_%s_%s", jobId, partitionId, attemptNumber));
+  }
+
+  @Override public void abort() throws IOException {
+    LOG.info("Driver sent abort for %s_%s_%s", jobId, partitionId, attemptNumber);
+    try {
+      out.close();
+    } finally {
+      fs.delete(filePath, false);
+    }
+  }
+
+  protected OutputWriter getOutputWriter(String path, StructType schema, TaskAttemptContext tac) {
+    return new OrcOutputWriter(path, schema, tac);
+  }
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
@@ -1,0 +1,47 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataWriter;
+import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+
+import java.io.IOException;
+
+public class HiveWarehouseDataWriterFactory implements DataWriterFactory<InternalRow> {
+
+  protected String jobId;
+  protected StructType schema;
+  protected Path path;
+  protected SerializableConfiguration conf;
+
+  public HiveWarehouseDataWriterFactory(String jobId, StructType schema, Path path,
+      SerializableConfiguration conf) {
+    this.jobId = jobId;
+    this.schema = schema;
+    this.path = path;
+    this.conf = conf;
+  }
+
+  @Override public DataWriter<InternalRow> createDataWriter(int partitionId, int attemptNumber) {
+    Path filePath = new Path(this.path, String.format("%s_%s_%s", jobId, partitionId, attemptNumber));
+    FileSystem fs = null;
+    try {
+      fs = filePath.getFileSystem(conf.value());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return getDataWriter(conf.value(), jobId, schema, partitionId, attemptNumber,
+        fs, filePath);
+  }
+
+  protected DataWriter<InternalRow> getDataWriter(Configuration conf, String jobId,
+      StructType schema, int partitionId, int attemptNumber,
+      FileSystem fs, Path filePath) {
+    return new HiveWarehouseDataWriter(conf, jobId, schema, partitionId, attemptNumber, fs, filePath);
+  }
+}
+

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
@@ -15,10 +15,10 @@ public class HiveWarehouseDataWriterFactory implements DataWriterFactory<Interna
 
   protected String jobId;
   protected StructType schema;
-  protected Path path;
+  protected String path;
   protected SerializableConfiguration conf;
 
-  public HiveWarehouseDataWriterFactory(String jobId, StructType schema, Path path,
+  public HiveWarehouseDataWriterFactory(String jobId, StructType schema, String path,
       SerializableConfiguration conf) {
     this.jobId = jobId;
     this.schema = schema;

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/SimpleWriterCommitMessage.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/SimpleWriterCommitMessage.java
@@ -1,0 +1,16 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+
+public class SimpleWriterCommitMessage implements WriterCommitMessage {
+  private String message;
+
+  public SimpleWriterCommitMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}
+

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/util/HiveQlUtil.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/util/HiveQlUtil.java
@@ -104,6 +104,9 @@ public class HiveQlUtil {
         return (useText ? text : "");
     }
 
+  public static String loadInto(String path, String database, String table) {
+    return format("LOAD DATA INPATH '%s' INTO TABLE %s.%s", path, database, table);
+  }
     public static String randomAlias() {
         return "q_" + UUID.randomUUID().toString().replaceAll("[^A-Za-z0-9 ]", "");
     }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import java.io.IOException;
 import java.sql.Struct;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +34,7 @@ import java.util.Optional;
 public class MockHiveWarehouseConnector extends HiveWarehouseConnector {
 
   public static int[] testVector = {1, 2, 3, 4, 5};
-  public static Map<String, Object> writeOutputBuffer;
+  public static Map<String, Object> writeOutputBuffer = new HashMap<>();
 
   @Override
   protected DataSourceReader getDataSourceReader(Map<String, String> params) throws IOException {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
@@ -6,15 +6,20 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.llap.LlapInputSplit;
 import org.apache.hadoop.hive.ql.io.arrow.ArrowWrapperWritable;
 import org.apache.hadoop.hive.ql.io.arrow.RootAllocatorFactory;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.reader.DataReader;
 import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
 import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
@@ -23,14 +28,22 @@ import java.sql.Struct;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class MockHiveWarehouseConnector extends HiveWarehouseConnector {
 
   public static int[] testVector = {1, 2, 3, 4, 5};
+  public static Map<String, Object> writeOutputBuffer;
 
   @Override
   protected DataSourceReader getDataSourceReader(Map<String, String> params) throws IOException {
     return new MockHiveWarehouseDataSourceReader(params);
+  }
+
+  @Override
+  protected DataSourceWriter getDataSourceWriter(String jobId, StructType schema,
+      Path path, Map<String, String> options, Configuration conf) {
+    return new MockWriteSupport.MockHiveWarehouseDataSourceWriter(options, jobId, schema, path, conf);
   }
 
   public static class MockHiveWarehouseDataReader extends HiveWarehouseDataReader {

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseSessionImpl.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseSessionImpl.java
@@ -34,7 +34,7 @@ public class MockHiveWarehouseSessionImpl extends HiveWarehouseSessionImpl {
         row.add(new GenericRow(new Object[] {2, "ID 2"}));
         StructType schema = (new StructType())
                 .add("col1", "int")
-                .add("col1", "string");
+                .add("col2", "string");
         return new DriverResultSet(row, schema);
     }
 

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
@@ -3,7 +3,7 @@ package com.hortonworks.spark.sql.hive.llap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.OutputWriter;
 import org.apache.spark.sql.execution.datasources.orc.OrcOutputWriter;

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
@@ -9,6 +9,7 @@ import org.apache.spark.sql.execution.datasources.OutputWriter;
 import org.apache.spark.sql.execution.datasources.orc.OrcOutputWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
 
@@ -30,13 +31,17 @@ public class MockWriteSupport {
 
     @Override
     public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
-      return new MockHiveWarehouseDataWriterFactory(jobId, schema, path, new SerializableConfiguration(conf));
+      return new MockHiveWarehouseDataWriterFactory(jobId, schema, path.toString(), new SerializableConfiguration(conf));
+    }
+
+    @Override public void commit(WriterCommitMessage[] messages) {
+
     }
   }
 
   public static class MockHiveWarehouseDataWriterFactory extends HiveWarehouseDataWriterFactory {
 
-    public MockHiveWarehouseDataWriterFactory(String jobId, StructType schema, Path path,
+    public MockHiveWarehouseDataWriterFactory(String jobId, StructType schema, String path,
         SerializableConfiguration conf) {
       super(jobId, schema, path, conf);
     }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockWriteSupport.java
@@ -1,0 +1,83 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.OutputWriter;
+import org.apache.spark.sql.execution.datasources.orc.OrcOutputWriter;
+import org.apache.spark.sql.sources.v2.writer.DataWriter;
+import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector.testVector;
+import static org.junit.Assert.assertEquals;
+
+public class MockWriteSupport {
+
+  public static class MockHiveWarehouseDataSourceWriter extends HiveWarehouseDataSourceWriter {
+
+    public MockHiveWarehouseDataSourceWriter(Map<String, String> options, String jobId, StructType schema, Path path,
+        Configuration conf) {
+      super(options, jobId, schema, path, conf);
+    }
+
+    @Override
+    public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
+      return new MockHiveWarehouseDataWriterFactory(jobId, schema, path, new SerializableConfiguration(conf));
+    }
+  }
+
+  public static class MockHiveWarehouseDataWriterFactory extends HiveWarehouseDataWriterFactory {
+
+    public MockHiveWarehouseDataWriterFactory(String jobId, StructType schema, Path path,
+        SerializableConfiguration conf) {
+      super(jobId, schema, path, conf);
+    }
+
+    protected DataWriter<InternalRow> getDataWriter(Configuration conf, String jobId,
+        StructType schema, int partitionId, int attemptNumber,
+        FileSystem fs, Path filePath) {
+      return new MockHiveWarehouseDataWriter(conf, jobId, schema, partitionId, attemptNumber, fs, filePath);
+    }
+
+  }
+
+  public static class MockHiveWarehouseDataWriter extends HiveWarehouseDataWriter {
+
+    public MockHiveWarehouseDataWriter(Configuration conf, String jobId, StructType schema, int partitionId,
+        int attemptNumber, FileSystem fs, Path filePath) {
+      super(conf, jobId, schema, partitionId, attemptNumber, fs, filePath);
+    }
+
+    @Override
+    protected OutputWriter getOutputWriter(String path, StructType schema, TaskAttemptContext tac) {
+      return new MockOutputWriter(path, schema, tac);
+    }
+
+  }
+
+  public static class MockOutputWriter extends OutputWriter {
+
+    public static List<InternalRow> rowBuffer = new ArrayList<>();
+    public static boolean closed = false;
+
+    public MockOutputWriter(String path, StructType schema, TaskAttemptContext tac) {
+    }
+
+    @Override public void write(InternalRow row) {
+      rowBuffer.add(row);
+    }
+
+    @Override public void close() {
+      MockHiveWarehouseConnector.writeOutputBuffer.put("TestWriteSupport", rowBuffer);
+    }
+  }
+
+}

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/TestWriteSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/TestWriteSupport.java
@@ -1,10 +1,13 @@
 package com.hortonworks.spark.sql.hive.llap;
 
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector.testVector;
 import static com.hortonworks.spark.sql.hive.llap.TestSecureHS2Url.TEST_HS2_URL;
@@ -20,12 +23,17 @@ public class TestWriteSupport extends SessionTestBase {
         build();
     HiveWarehouseSessionImpl impl = (HiveWarehouseSessionImpl) hive;
     impl.HIVE_WAREHOUSE_CONNECTOR_INTERNAL = "com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector";
-    
+    DriverResultSet input = MockHiveWarehouseSessionImpl.testFixture();
+    Dataset df = session.createDataFrame(input.data, input.schema);
+    df.write().format(impl.HIVE_WAREHOUSE_CONNECTOR_INTERNAL).option("table", "fakeTable").save();
     List<InternalRow> rows = (List<InternalRow>) MockHiveWarehouseConnector.writeOutputBuffer.get("TestWriteSupport");
+    Map<Integer, String> unorderedOutput = new HashMap<>();
     for(int i = 0; i < rows.size(); i++) {
       InternalRow current = rows.get(i);
-      assertEquals(current.getInt(0), testVector[i]);
+      unorderedOutput.put(current.getInt(0), current.getString(1));
     }
+    assertEquals(unorderedOutput.get(1), "ID 1");
+    assertEquals(unorderedOutput.get(2), "ID 2");
   }
 
 }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/TestWriteSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/TestWriteSupport.java
@@ -1,0 +1,31 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector.testVector;
+import static com.hortonworks.spark.sql.hive.llap.TestSecureHS2Url.TEST_HS2_URL;
+import static org.junit.Assert.assertEquals;
+
+public class TestWriteSupport extends SessionTestBase {
+
+  @Test
+  public void testWriteSupport() {
+    HiveWarehouseSession hive = HiveWarehouseBuilder.
+        session(session).
+        hs2url(TEST_HS2_URL).
+        build();
+    HiveWarehouseSessionImpl impl = (HiveWarehouseSessionImpl) hive;
+    impl.HIVE_WAREHOUSE_CONNECTOR_INTERNAL = "com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector";
+    
+    List<InternalRow> rows = (List<InternalRow>) MockHiveWarehouseConnector.writeOutputBuffer.get("TestWriteSupport");
+    for(int i = 0; i < rows.size(); i++) {
+      InternalRow current = rows.get(i);
+      assertEquals(current.getInt(0), testVector[i]);
+    }
+  }
+
+}

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -51,6 +51,11 @@ class TestJavaProxy extends FunSuite {
     withSetUpAndTearDown(test, test.nonKerberized)
   }
 
+  test("TestWriteSupport") {
+    val test = new TestWriteSupport()
+    withSetUpAndTearDown(test, test.testWriteSupport);
+  }
+
   test("TestReadSupport") {
     val test = new TestReadSupport()
     withSetUpAndTearDown(test, test.testReadSupport);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add batch WriteSupport:
1. Write DataFrame to ORC temp dir
2. Use HS2 to "LOAD DATA INPATH" from ORC files to target table
3. Delete temp dir

## How was this patch tested?

UT
