### PR TITLE
Add count support for branch-2.3-3.0

### DIFF
--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReader.java
@@ -1,0 +1,40 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import java.io.IOException;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+
+public class CountDataReader implements DataReader<ColumnarBatch> {
+  private long numRows;
+
+  public CountDataReader(long numRows) {
+    this.numRows = numRows;
+  }
+
+  @Override public boolean next() throws IOException {
+    if(numRows < 0) {
+      throw new IOException();
+    }
+    return numRows > 0;
+  }
+
+  @Override public ColumnarBatch get() {
+    int size = (numRows >= 1000) ? 1000 : (int) numRows;
+    OnHeapColumnVector vector = new OnHeapColumnVector(size, DataTypes.LongType);
+    for(int i = 0; i < size; i++) {
+      vector.putLong(0, numRows);
+    }
+    numRows -= size;
+    ColumnarBatch batch = new ColumnarBatch(new ColumnVector[] {vector});
+    batch.setNumRows(size);
+    return batch;
+  }
+
+  @Override
+  public void close() {
+    //NOOP
+  }
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReaderFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReaderFactory.java
@@ -1,0 +1,18 @@
+package com.hortonworks.spark.sql.hive.llap;
+
+import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+public class CountDataReaderFactory implements DataReaderFactory<ColumnarBatch> {
+  private long numRows;
+
+  public CountDataReaderFactory(long numRows) {
+    this.numRows = numRows;
+  }
+
+  @Override
+  public DataReader<ColumnarBatch> createDataReader() {
+    return new CountDataReader(numRows);
+  }
+}

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
@@ -38,7 +38,8 @@ public enum HWConf {
   DEFAULT_DB("default.db", warehouseKey("default.db"), "default"),
   MAX_EXEC_RESULTS("exec.results.max", warehouseKey("exec.results.max"), 1000),
   LOAD_STAGING_DIR("load.staging.dir", warehouseKey("load.staging.dir"), "/tmp"),
-  ARROW_ALLOCATOR_MAX("arrow.allocator.max", warehouseKey("arrow.allocator.max"), Long.MAX_VALUE);
+  ARROW_ALLOCATOR_MAX("arrow.allocator.max", warehouseKey("arrow.allocator.max"), Long.MAX_VALUE),
+  COUNT_TASKS("count.tasks", warehouseKey("count.tasks"), 100);
 
   private HWConf(String simpleKey, String qualifiedKey, Object defaultValue) {
     this.simpleKey = simpleKey;

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/MockHiveWarehouseConnector.java
@@ -35,6 +35,7 @@ public class MockHiveWarehouseConnector extends HiveWarehouseConnector {
 
   public static int[] testVector = {1, 2, 3, 4, 5};
   public static Map<String, Object> writeOutputBuffer = new HashMap<>();
+  public static long COUNT_STAR_TEST_VALUE = 1024;
 
   @Override
   protected DataSourceReader getDataSourceReader(Map<String, String> params) throws IOException {
@@ -99,6 +100,12 @@ public class MockHiveWarehouseConnector extends HiveWarehouseConnector {
 
     protected List<DataReaderFactory<ColumnarBatch>> getSplitsFactories(String query) {
       return Lists.newArrayList(new MockHiveWarehouseDataReaderFactory(null, null, 0));
+    }
+
+    @Override
+    protected long getCount(String query) {
+      //Mock out the call to HS2 to get the count
+      return COUNT_STAR_TEST_VALUE;
     }
 
   }

--- a/src/test/java/com/hortonworks/spark/sql/hive/llap/TestReadSupport.java
+++ b/src/test/java/com/hortonworks/spark/sql/hive/llap/TestReadSupport.java
@@ -22,4 +22,16 @@ public class TestReadSupport extends SessionTestBase {
     }
   }
 
+  @Test
+  public void testCountSupport() {
+    HiveWarehouseSession hive = HiveWarehouseBuilder.
+        session(session).
+        hs2url(TEST_HS2_URL).
+        build();
+    HiveWarehouseSessionImpl impl = (HiveWarehouseSessionImpl) hive;
+    impl.HIVE_WAREHOUSE_CONNECTOR_INTERNAL = "com.hortonworks.spark.sql.hive.llap.MockHiveWarehouseConnector";
+    long count = hive.executeQuery("SELECT a from fake").count();
+    assertEquals(count, MockHiveWarehouseConnector.COUNT_STAR_TEST_VALUE);
+  }
+
 }

--- a/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
+++ b/src/test/scala/com/hortonworks/spark/sql/hive/llap/TestJavaProxy.scala
@@ -54,6 +54,7 @@ class TestJavaProxy extends FunSuite {
   test("TestReadSupport") {
     val test = new TestReadSupport()
     withSetUpAndTearDown(test, test.testReadSupport);
+    withSetUpAndTearDown(test, test.testCountSupport);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate the logic from master branch that specially handles `.count()` action.

Instead of using parallelize, when the count value from HS2 is `X`:

1. Launch `COUNT_TASKS` num of tasks (configurable)
2. `(COUNT_TASKS - 1)` tasks generate `X/(COUNT_TASKS - 1)` rows.
3. 1 task generates `X % (COUNT_TASKS - 1)` rows

## How was this patch tested?

UT
