### PR TITLE
[SPARK-LLAP-248] Use Apache Spark 2.3.1 and Hadoop 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ language: python
 
 matrix:
   include:
-    # Spark 2.3.0
+    # Spark 2.3.1
     - jdk: oraclejdk8
       python: 2.7
       env: >
-        TEST_SPARK_VERSION=2.3.0
+        TEST_SPARK_VERSION=2.3.1
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,9 @@ organization := "com.hortonworks.spark"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
-sparkVersion := sys.props.getOrElse("spark.version", "2.3.0")
+sparkVersion := sys.props.getOrElse("spark.version", "2.3.1")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.0.0")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.1.0")
 val hiveVersion = sys.props.getOrElse("hive.version", "3.0.0")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
 val tezVersion = sys.props.getOrElse("tez.version", "0.9.1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This bumps Apache Spark version to 2.3.1.

## How was this patch tested?

Like before, `branch-2.3-3.0` build will fail.

This closes #248 .