### PR TITLE
added brackets to logical expression to correctly distinguish between…

### DIFF
--- a/src/main/scala/com/hortonworks/spark/sql/hive/llap/FilterPushdown.scala
+++ b/src/main/scala/com/hortonworks/spark/sql/hive/llap/FilterPushdown.scala
@@ -80,7 +80,7 @@ private[llap] object FilterPushdown extends Object {
       if (leftExpr.isEmpty || rightExpr.isEmpty) {
         return None
       }
-      Option(s"(${leftExpr.get}) ${op} (${rightExpr.get})")
+      Option(s"((${leftExpr.get}) ${op} (${rightExpr.get}))")
     }
 
     def buildNotExpr(operand: Filter): Option[String] = {


### PR DESCRIPTION
issue : https://github.com/hortonworks-spark/spark-llap/issues/273

## What changes were proposed in this pull request?

As a user if we add multiple filters with "or" operator on spark dataframe it should be enclosed properly with correct brackets but in the current version of hwc multiple filters are not enclosed with proper brackets
for e.g.
df = df.fiter("condition1 or condition2")
df = df.filter("condition3 and condition4")

the resultant query created is as follows

(condition1) or (condition2) and (condition3) and (condition4)
ideally it should be as follows
((condition1) or (condition2)) and ((condition3) and (condition4))

## How was this patch tested?
manual tests

