### PR TITLE
making hive warehouse connector compatible with spark 2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ organization := "com.hortonworks.hive"
 scalaVersion := "2.11.8"
 val scalatestVersion = "2.2.6"
 
-sparkVersion := sys.props.getOrElse("spark.version", "2.3.1")
+sparkVersion := sys.props.getOrElse("spark.version", "2.4.0")
 
-val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.1.0")
-val hiveVersion = sys.props.getOrElse("hive.version", "3.0.0")
+val hadoopVersion = sys.props.getOrElse("hadoop.version", "3.2.0")
+val hiveVersion = sys.props.getOrElse("hive.version", "3.1.1")
 val log4j2Version = sys.props.getOrElse("log4j2.version", "2.4.1")
 val tezVersion = sys.props.getOrElse("tez.version", "0.9.1")
 val thriftVersion = sys.props.getOrElse("thrift.version", "0.9.3")

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReader.java
@@ -3,11 +3,11 @@ package com.hortonworks.spark.sql.hive.llap;
 import java.io.IOException;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
-import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.sources.v2.reader.*;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.types.DataTypes;
 
-public class CountDataReader implements DataReader<ColumnarBatch> {
+public class CountDataReader implements InputPartitionReader<ColumnarBatch> {
   private long numRows;
 
   public CountDataReader(long numRows) {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReaderFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/CountDataReaderFactory.java
@@ -1,18 +1,16 @@
 package com.hortonworks.spark.sql.hive.llap;
 
-import org.apache.spark.sql.sources.v2.reader.DataReader;
-import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
+import org.apache.spark.sql.sources.v2.reader.*;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
-public class CountDataReaderFactory implements DataReaderFactory<ColumnarBatch> {
+public class CountDataReaderFactory implements InputPartition<ColumnarBatch> {
   private long numRows;
 
   public CountDataReaderFactory(long numRows) {
     this.numRows = numRows;
   }
 
-  @Override
-  public DataReader<ColumnarBatch> createDataReader() {
+  public InputPartitionReader<ColumnarBatch> createPartitionReader() {
     return new CountDataReader(numRows);
   }
 }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HWConf.java
@@ -53,7 +53,8 @@ public enum HWConf {
 
   private static Logger LOG = LoggerFactory.getLogger(HWConf.class);
   public static final String HIVESERVER2_CREDENTIAL_ENABLED = "spark.security.credentials.hiveserver2.enabled";
-  public static final String HIVESERVER2_JDBC_URL_PRINCIPAL = "spark.sql.hive.hiveserver2.jdbc.url.principal";
+  public static final String HIVESERVER2_JDBC_URL_PRINCIPAL = "" +
+          "spark.sql.hive.hiveserver2.jdbc.url.principal";
   public static final String HIVESERVER2_JDBC_URL = "spark.sql.hive.hiveserver2.jdbc.url";
 
   public void setString(HiveWarehouseSessionState state, String value) {

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataSourceWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataSourceWriter.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
-import org.apache.spark.sql.sources.v2.writer.SupportsWriteInternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow {
+public class HiveStreamingDataSourceWriter implements DataSourceWriter {
   private static Logger LOG = LoggerFactory.getLogger(HiveStreamingDataSourceWriter.class);
 
   private String jobId;
@@ -23,7 +23,7 @@ public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow {
   private String metastoreKrbPrincipal;
 
   public HiveStreamingDataSourceWriter(String jobId, StructType schema, long commitIntervalRows, String db,
-    String table, List<String> partition, final String metastoreUri, final String metastoreKrbPrincipal) {
+                                       String table, List<String> partition, final String metastoreUri, final String metastoreKrbPrincipal) {
     this.jobId = jobId;
     this.schema = schema;
     this.commitIntervalRows = commitIntervalRows;
@@ -35,9 +35,9 @@ public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow {
   }
 
   @Override
-  public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
+  public DataWriterFactory<InternalRow> createWriterFactory() {
     return new HiveStreamingDataWriterFactory(jobId, schema, commitIntervalRows, db, table, partition, metastoreUri,
-      metastoreKrbPrincipal);
+            metastoreKrbPrincipal);
   }
 
   @Override
@@ -50,4 +50,3 @@ public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow {
     LOG.info("Abort job {}", jobId);
   }
 }
-

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataWriter.java
@@ -25,7 +25,7 @@ public class HiveStreamingDataWriter implements DataWriter<InternalRow> {
   private String jobId;
   private StructType schema;
   private int partitionId;
-  private int attemptNumber;
+  private long attemptNumber;
   private String db;
   private String table;
   private List<String> partition;
@@ -35,7 +35,7 @@ public class HiveStreamingDataWriter implements DataWriter<InternalRow> {
   private long rowsWritten = 0;
   private String metastoreKrbPrincipal;
 
-  public HiveStreamingDataWriter(String jobId, StructType schema, long commitAfterNRows, int partitionId, int
+  public HiveStreamingDataWriter(String jobId, StructType schema, long commitAfterNRows, int partitionId, long
     attemptNumber, String db, String table, List<String> partition, final String metastoreUri,
     final String metastoreKrbPrincipal) {
     this.jobId = jobId;

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataWriterFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveStreamingDataWriterFactory.java
@@ -21,7 +21,7 @@ public class HiveStreamingDataWriterFactory implements DataWriterFactory<Interna
   private String metastoreKrbPrincipal;
 
   public HiveStreamingDataWriterFactory(String jobId, StructType schema, long commitIntervalRows, String db,
-    String table, List<String> partition, final String metastoreUri, final String metastoreKrbPrincipal) {
+                                        String table, List<String> partition, final String metastoreUri, final String metastoreKrbPrincipal) {
     this.jobId = jobId;
     this.schema = schema;
     this.db = db;
@@ -33,16 +33,15 @@ public class HiveStreamingDataWriterFactory implements DataWriterFactory<Interna
   }
 
   @Override
-  public DataWriter<InternalRow> createDataWriter(int partitionId, int attemptNumber) {
+  public DataWriter<InternalRow> createDataWriter(int partitionId, long attemptNumber,long epochId) {
     ClassLoader restoredClassloader = Thread.currentThread().getContextClassLoader();
     ClassLoader isolatedClassloader = HiveIsolatedClassLoader.isolatedClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(isolatedClassloader);
       return new HiveStreamingDataWriter(jobId, schema, commitIntervalRows, partitionId, attemptNumber, db,
-        table, partition, metastoreUri, metastoreKrbPrincipal);
+              table, partition, metastoreUri, metastoreKrbPrincipal);
     } finally {
       Thread.currentThread().setContextClassLoader(restoredClassloader);
     }
   }
 }
-

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReader.java
@@ -7,7 +7,7 @@ import org.apache.hadoop.hive.llap.LlapInputSplit;
 import org.apache.hadoop.hive.ql.io.arrow.ArrowWrapperWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
-import org.apache.spark.sql.sources.v2.reader.DataReader;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
 import org.apache.spark.sql.vectorized.ArrowColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -28,7 +28,7 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.hadoop.hive.ql.io.arrow.RootAllocatorFactory;
 
-public class HiveWarehouseDataReader implements DataReader<ColumnarBatch> {
+public class HiveWarehouseDataReader implements InputPartitionReader<ColumnarBatch> {
 
   private RecordReader<?, ArrowWrapperWritable> reader;
   private ArrowWrapperWritable wrapperWritable = new ArrowWrapperWritable();
@@ -67,7 +67,7 @@ public class HiveWarehouseDataReader implements DataReader<ColumnarBatch> {
         attemptId,
         childAllocatorReservation,
         arrowAllocatorMax);
-    LlapBaseInputFormat input = new LlapBaseInputFormat(true, allocator);
+    LlapBaseInputFormat input = new LlapBaseInputFormat(true, arrowAllocatorMax);
     return input.getRecordReader(split, conf, null);
   }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataReaderFactory.java
@@ -3,8 +3,8 @@ package com.hortonworks.spark.sql.hive.llap;
 import org.apache.hadoop.hive.llap.LlapInputSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.spark.sql.sources.v2.reader.DataReader;
-import org.apache.spark.sql.sources.v2.reader.DataReaderFactory;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.ByteArrayInputStream;
@@ -12,7 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
-public class HiveWarehouseDataReaderFactory implements DataReaderFactory<ColumnarBatch> {
+public class HiveWarehouseDataReaderFactory implements InputPartition<ColumnarBatch> {
     private byte[] splitBytes;
     private byte[] confBytes;
     private transient InputSplit split;
@@ -51,7 +51,7 @@ public class HiveWarehouseDataReaderFactory implements DataReaderFactory<Columna
     }
 
     @Override
-    public DataReader<ColumnarBatch> createDataReader() {
+    public InputPartitionReader<ColumnarBatch> createPartitionReader() {
         LlapInputSplit llapInputSplit = new LlapInputSplit();
         ByteArrayInputStream splitByteArrayStream = new ByteArrayInputStream(splitBytes);
         ByteArrayInputStream confByteArrayStream = new ByteArrayInputStream(confBytes);
@@ -67,7 +67,7 @@ public class HiveWarehouseDataReaderFactory implements DataReaderFactory<Columna
         }
     }
 
-    protected DataReader<ColumnarBatch> getDataReader(LlapInputSplit split, JobConf jobConf, long arrowAllocatorMax)
+    protected InputPartitionReader<ColumnarBatch> getDataReader(LlapInputSplit split, JobConf jobConf, long arrowAllocatorMax)
         throws Exception {
         return new HiveWarehouseDataReader(split, jobConf, arrowAllocatorMax);
     }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataSourceWriter.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
-import org.apache.spark.sql.sources.v2.writer.SupportsWriteInternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
@@ -35,7 +35,7 @@ import java.util.Map;
 
 import static com.hortonworks.spark.sql.hive.llap.util.HiveQlUtil.loadInto;
 
-public class HiveWarehouseDataSourceWriter implements SupportsWriteInternalRow {
+public class HiveWarehouseDataSourceWriter implements DataSourceWriter {
   protected String jobId;
   protected StructType schema;
   protected Path path;
@@ -52,7 +52,7 @@ public class HiveWarehouseDataSourceWriter implements SupportsWriteInternalRow {
     this.conf = conf;
   }
 
-  @Override public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
+  @Override public DataWriterFactory<InternalRow>  createWriterFactory() {
     return new HiveWarehouseDataWriterFactory(jobId, schema, path, new SerializableHadoopConfiguration(conf));
   }
 

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriter.java
@@ -23,13 +23,13 @@ public class HiveWarehouseDataWriter implements DataWriter<InternalRow> {
   private String jobId;
   private StructType schema;
   private int partitionId;
-  private int attemptNumber;
+  private long attemptNumber;
   private FileSystem fs;
   private Path filePath;
   private OutputWriter out;
 
   public HiveWarehouseDataWriter(Configuration conf, String jobId, StructType schema,
-      int partitionId, int attemptNumber, FileSystem fs, Path filePath) {
+      int partitionId, long attemptNumber, FileSystem fs, Path filePath) {
     this.jobId = jobId;
     this.schema = schema;
     this.partitionId = partitionId;

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/HiveWarehouseDataWriterFactory.java
@@ -29,7 +29,7 @@ public class HiveWarehouseDataWriterFactory implements DataWriterFactory<Interna
     this.conf = conf;
   }
 
-  @Override public DataWriter<InternalRow> createDataWriter(int partitionId, int attemptNumber) {
+  @Override public DataWriter<InternalRow> createDataWriter(int partitionId, long attemptNumber,long epochId) {
     Path filePath = new Path(this.path, String.format("%s_%s_%s", jobId, partitionId, attemptNumber));
     FileSystem fs = null;
     try {
@@ -42,7 +42,7 @@ public class HiveWarehouseDataWriterFactory implements DataWriterFactory<Interna
   }
 
   protected DataWriter<InternalRow> getDataWriter(Configuration conf, String jobId,
-      StructType schema, int partitionId, int attemptNumber,
+      StructType schema, int partitionId, long attemptNumber,
       FileSystem fs, Path filePath) {
     return new HiveWarehouseDataWriter(conf, jobId, schema, partitionId, attemptNumber, fs, filePath);
   }

--- a/src/main/java/com/hortonworks/spark/sql/hive/llap/streaming/HiveStreamingDataSourceWriter.java
+++ b/src/main/java/com/hortonworks/spark/sql/hive/llap/streaming/HiveStreamingDataSourceWriter.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
-import org.apache.spark.sql.sources.v2.writer.SupportsWriteInternalRow;
+import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter;
 import org.apache.spark.sql.types.StructType;
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import com.hortonworks.spark.sql.hive.llap.HiveStreamingDataWriterFactory;
 
-public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow, StreamWriter {
+public class HiveStreamingDataSourceWriter implements DataSourceWriter, StreamWriter {
   private static Logger LOG = LoggerFactory.getLogger(HiveStreamingDataSourceWriter.class);
 
   private String jobId;
@@ -36,7 +36,7 @@ public class HiveStreamingDataSourceWriter implements SupportsWriteInternalRow, 
   }
 
   @Override
-  public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
+  public DataWriterFactory<InternalRow> createWriterFactory() {
     // for the streaming case, commit transaction happens on task commit() (atleast-once), so interval is set to -1
     return new HiveStreamingDataWriterFactory(jobId, schema, -1, db, table, partition, metastoreUri,
       metastoreKerberosPrincipal);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently method like executeQuery does not work when running this library with spark 2.4.0 because in spark 2.4.0 some classes have been removed and some classes have been renamed

DataReaderFactory have been renamed to InputPartition
2)DataReader have been renamed to InputPartitionReader
3)SupportsWriteInternalRow have been removed

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
